### PR TITLE
Add different gpu options for qdrant

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -178,3 +178,33 @@ COMPOSE_FILE=docker-compose.yml
 # COMPOSE_FILE=docker-compose.remote.yml:docker-compose.gpu.yml
 # Windows
 # COMPOSE_FILE=docker-compose.remote.yml;docker-compose.gpu.yml
+
+# ============================================
+# QDRANT GPU ACCELERATION
+# ============================================
+
+# Qdrant supports GPU acceleration for vector indexing.
+# By default, docker-compose.yml uses CPU-only Qdrant.
+# Add the appropriate override file to enable GPU acceleration.
+#
+# ┌─────────────────────────────────────────────────────────────────┐
+# │ OPTION A: Qdrant with NVIDIA GPU                                │
+# │ Requirements: NVIDIA drivers + nvidia-container-toolkit         │
+# └─────────────────────────────────────────────────────────────────┘
+# COMPOSE_FILE=docker-compose.yml:docker-compose.qdrant-nvidia.yml
+#
+# ┌─────────────────────────────────────────────────────────────────┐
+# │ OPTION B: Qdrant with AMD GPU (ROCm)                            │
+# │ Requirements: AMD ROCm drivers, /dev/kfd and /dev/dri access    │
+# │               User must be in 'video' and 'render' groups       │
+# └─────────────────────────────────────────────────────────────────┘
+# COMPOSE_FILE=docker-compose.yml:docker-compose.qdrant-amd.yml
+#
+# ┌─────────────────────────────────────────────────────────────────┐
+# │ COMBINED: Full stack with GPU for both app and Qdrant           │
+# └─────────────────────────────────────────────────────────────────┘
+# App GPU + Qdrant NVIDIA GPU:
+# COMPOSE_FILE=docker-compose.yml:docker-compose.gpu.yml:docker-compose.qdrant-nvidia.yml
+#
+# App GPU + Qdrant AMD GPU:
+# COMPOSE_FILE=docker-compose.yml:docker-compose.gpu.yml:docker-compose.qdrant-amd.yml

--- a/README.md
+++ b/README.md
@@ -113,11 +113,13 @@ QUESTDB_HOST=localhost
 
 ### Archivos Docker Compose Disponibles
 
-| Archivo                     | Descripción                                              |
-| --------------------------- | -------------------------------------------------------- |
-| `docker-compose.yml`        | Stack completo local (app, questdb, dashboard, init)     |
-| `docker-compose.remote.yml` | Solo app y dashboard, conecta a QuestDB remoto           |
-| `docker-compose.gpu.yml`    | Override para habilitar soporte GPU en el servicio `app` |
+| Archivo                            | Descripción                                              |
+| ---------------------------------- | -------------------------------------------------------- |
+| `docker-compose.yml`               | Stack completo local (app, questdb, dashboard, init)     |
+| `docker-compose.remote.yml`        | Solo app y dashboard, conecta a QuestDB remoto           |
+| `docker-compose.gpu.yml`           | Override para habilitar soporte GPU en el servicio `app` |
+| `docker-compose.qdrant-nvidia.yml` | Override para Qdrant con GPU NVIDIA                      |
+| `docker-compose.qdrant-amd.yml`    | Override para Qdrant con GPU AMD (ROCm)                  |
 
 ### Opción 1: Docker Stack Completo (Recomendada)
 
@@ -172,7 +174,7 @@ Esto iniciará:
 - **Dashboard**: [http://localhost:3001](http://localhost:3001)
 - **Cliente Streamlit**: [http://localhost:8501](http://localhost:8501)
 
-### Opción 3: Docker con Soporte GPU
+### Opción 3: Docker con Soporte GPU (App)
 
 El servicio `app` puede utilizar GPU para acelerar el procesamiento. Para habilitar GPU:
 
@@ -206,7 +208,45 @@ docker compose -f docker-compose.yml -f docker-compose.gpu.yml up --build
 > - En **Linux/macOS** se utiliza el signo de dos puntos (`:`) como separador.
 > - En **Windows** se debe utilizar el punto y coma (`;`) como separador.
 
-### Opción 4: Desarrollo Local
+### Opción 4: Qdrant con Aceleración GPU
+
+Qdrant soporta aceleración GPU para indexación vectorial. Por defecto, se usa la versión CPU. Puedes habilitar GPU utilizando los archivos de override correspondientes:
+
+#### GPU NVIDIA
+
+```bash
+# Usando variable de entorno (en .env):
+COMPOSE_FILE=docker-compose.yml:docker-compose.qdrant-nvidia.yml
+
+# O mediante línea de comandos:
+docker compose -f docker-compose.yml -f docker-compose.qdrant-nvidia.yml up
+
+# Combinando con GPU para app:
+COMPOSE_FILE=docker-compose.yml:docker-compose.gpu.yml:docker-compose.qdrant-nvidia.yml
+```
+
+**Requisitos NVIDIA:**
+
+- Drivers NVIDIA instalados
+- [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html)
+
+#### GPU AMD (ROCm)
+
+```bash
+# Usando variable de entorno (en .env):
+COMPOSE_FILE=docker-compose.yml:docker-compose.qdrant-amd.yml
+
+# O mediante línea de comandos:
+docker compose -f docker-compose.yml -f docker-compose.qdrant-amd.yml up
+```
+
+**Requisitos AMD:**
+
+- Drivers AMD ROCm instalados
+- Dispositivos `/dev/kfd` y `/dev/dri` accesibles
+- Usuario en los grupos `video` y `render`
+
+### Opción 5: Desarrollo Local
 
 #### Cliente Python
 
@@ -249,7 +289,9 @@ ASM2-client/
 ├── questdb/               # Datos persistentes de QuestDB (generado)
 ├── docker-compose.yml     # Stack completo local
 ├── docker-compose.remote.yml  # Configuración para QuestDB remoto
-├── docker-compose.gpu.yml # Override para soporte GPU
+├── docker-compose.gpu.yml # Override para soporte GPU (app)
+├── docker-compose.qdrant-nvidia.yml # Override para Qdrant GPU NVIDIA
+├── docker-compose.qdrant-amd.yml    # Override para Qdrant GPU AMD
 ├── .env.example           # Plantilla de variables de entorno
 └── Dockerfile             # Imagen del cliente Python
 ```

--- a/docker-compose.qdrant-amd.yml
+++ b/docker-compose.qdrant-amd.yml
@@ -1,0 +1,16 @@
+# Qdrant AMD GPU override configuration
+# Usage:
+#   - Via COMPOSE_FILE env var: Set COMPOSE_FILE=docker-compose.yml:docker-compose.qdrant-amd.yml in .env
+#   - Via command line: docker compose -f docker-compose.yml -f docker-compose.qdrant-amd.yml up
+services:
+  qdrant:
+    image: qdrant/qdrant:gpu-amd-latest
+    environment:
+      # enable GPU indexing inside Qdrant
+      - QDRANT__GPU__INDEXING=1
+    devices:
+      - /dev/kfd:/dev/kfd # AMD Kernel Fusion Driver
+      - /dev/dri:/dev/dri # Direct Rendering Infrastructure
+    group_add:
+      - video
+      - render

--- a/docker-compose.qdrant-nvidia.yml
+++ b/docker-compose.qdrant-nvidia.yml
@@ -1,0 +1,17 @@
+# Qdrant NVIDIA GPU override configuration
+# Usage:
+#   - Via COMPOSE_FILE env var: Set COMPOSE_FILE=docker-compose.yml:docker-compose.qdrant-nvidia.yml in .env
+#   - Via command line: docker compose -f docker-compose.yml -f docker-compose.qdrant-nvidia.yml up
+services:
+  qdrant:
+    image: qdrant/qdrant:gpu-nvidia-latest
+    environment:
+      # enable GPU indexing inside Qdrant
+      - QDRANT__GPU__INDEXING=1
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,18 +64,14 @@ services:
     entrypoint: ["sh", "/init/init.sh"]
 
   qdrant:
-    image: qdrant/qdrant:gpu-nvidia-latest
+    image: qdrant/qdrant:latest
     container_name: qdrant
     restart: unless-stopped
     ports:
-      - "6333:6333"   # HTTP / REST API
-      - "6334:6334"   # gRPC
-    environment:
-      # enable GPU indexing inside Qdrant
-      - QDRANT__GPU__INDEXING=1
+      - "6333:6333" # HTTP / REST API
+      - "6334:6334" # gRPC
     volumes:
       - ./qdrant_index:/qdrant/storage
-    gpus: all
 
   dashboard:
     build:

--- a/run.sh
+++ b/run.sh
@@ -13,4 +13,4 @@ for f in "${REQUIRED_FILES[@]}"; do
   fi
 done
 
-docker compose up --build
+docker compose -f docker-compose.yml -f docker-compose.gpu.yml -f docker-compose.qdrant-nvidia.yml up --build


### PR DESCRIPTION
Add Qdrant GPU acceleration support (NVIDIA & AMD)
Summary
This PR adds configurable GPU acceleration options for Qdrant, allowing users to choose between CPU-only, NVIDIA GPU, or AMD GPU (ROCm) configurations.

New Files:
docker-compose.qdrant-nvidia.yml
 - Override for Qdrant with NVIDIA GPU support
docker-compose.qdrant-amd.yml
 - Override for Qdrant with AMD GPU (ROCm) support

Modified Files:
docker-compose.yml
 - Changed Qdrant to use CPU-only image (qdrant/qdrant:latest) as default
run.sh
 - Updated to use full GPU stack (app + Qdrant NVIDIA)
README.md
 - Added documentation for new GPU configurations
.env.example
 - Added Qdrant GPU configuration examples

Usage
# CPU only (default)
docker compose up
# NVIDIA GPU
docker compose -f docker-compose.yml -f docker-compose.qdrant-nvidia.yml up
# AMD GPU (ROCm)
docker compose -f docker-compose.yml -f docker-compose.qdrant-amd.yml up
# Full GPU stack (via run.sh)
./run.sh

Requirements
NVIDIA GPU: nvidia-container-toolkit + NVIDIA drivers
AMD GPU: ROCm drivers + user in video and render groups

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced deployment guidance with GPU acceleration instructions for Qdrant (NVIDIA and AMD support)
  * Updated .env.example with GPU configuration options

* **New Features**
  * Added AMD GPU acceleration support via docker-compose override
  * Added NVIDIA GPU acceleration support via docker-compose override

* **Configuration**
  * Updated base Docker Compose to use standard Qdrant image
  * Modified startup script to support composing multiple configuration files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->