### PR TITLE
Deshabilitar el chat la primera vez que se cargan datos en qdrant

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "cSpell.words": [
+    "Actívalo",
     "addgroup",
     "adduser",
     "ainvoke",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -118,6 +118,7 @@
     "Topbar",
     "typesafety",
     "unrs",
+    "unstub",
     "userinfo",
     "uvicorn",
     "vectordb",

--- a/backend/server.py
+++ b/backend/server.py
@@ -198,12 +198,13 @@ def run_vdb_update_once() -> None:
         return
 
     logging.info("Updating VDB...")
-    vectorstore = app.state.vectorstore
-    manifest = VDBManifest(QDRANT_META_PATH)
-    initial_build_in_progress = not manifest.is_initialized()
 
     try:
         start_time = time.time()
+
+        vectorstore = app.state.vectorstore
+        manifest = VDBManifest(QDRANT_META_PATH)
+        initial_build_in_progress = not manifest.is_initialized()
 
         questdb_pool = app.state.questdb_pool
         embeddings = vectorstore.embeddings

--- a/backend/server.py
+++ b/backend/server.py
@@ -199,9 +199,8 @@ def run_vdb_update_once() -> None:
 
     logging.info("Updating VDB...")
     vectorstore = app.state.vectorstore
-    collection_existed_before = vectorstore.client.collection_exists(QDRANT_COL)
-    initial_build_in_progress = not collection_existed_before
     manifest = VDBManifest(QDRANT_META_PATH)
+    initial_build_in_progress = not manifest.is_initialized()
 
     try:
         start_time = time.time()
@@ -222,6 +221,7 @@ def run_vdb_update_once() -> None:
         build_vectordb_from_sources(llm, embeddings, sources)
 
         if initial_build_in_progress:
+            manifest = VDBManifest(QDRANT_META_PATH)
             manifest.set_initialized()
             manifest.save()
 
@@ -345,29 +345,9 @@ def build_sources_status(questdb_pool, user_id: str) -> dict[str, Any]:
         source for source in selected_sources if source in connected_set
     )
     vdb_indexing_active = os.path.isfile(VDB_LOCK)
-    vectorstore = getattr(app.state, "vectorstore", None)
     manifest = VDBManifest(QDRANT_META_PATH)
 
-    try:
-        vdb_ready = bool(
-            vectorstore is not None
-            and vectorstore.client.collection_exists(QDRANT_COL)
-        )
-    except Exception:
-        logging.exception("Failed to determine Qdrant readiness")
-        vdb_ready = False
-
     initial_build_completed = manifest.is_initialized()
-
-    if (
-        not initial_build_completed
-        and not vdb_indexing_active
-        and vdb_ready
-        and manifest.num_chunks() > 0
-    ):
-        manifest.set_initialized()
-        manifest.save()
-        initial_build_completed = True
 
     return {
         "connected_sources": connected_sources,
@@ -375,7 +355,6 @@ def build_sources_status(questdb_pool, user_id: str) -> dict[str, Any]:
         "vdb_indexing_active": vdb_indexing_active,
         "can_chat": (
             len(selected_connected_sources) > 0
-            and vdb_ready
             and initial_build_completed
         ),
     }

--- a/backend/server.py
+++ b/backend/server.py
@@ -26,10 +26,13 @@ from src.config.logto_auth import AuthInfo, has_role
 from src.connectors.source import DataSource
 from src.config.sources import SOURCES
 from src.connectors.store import (
+    QDRANT_COL,
+    QDRANT_META_PATH,
     VDB_LOCK,
     build_vectordb_from_sources,
     get_vectordb,
 )
+from src.connectors.manifest import VDBManifest
 
 from src.model.endpoints import *
 from src.utils.helpers import periodic_task
@@ -195,12 +198,16 @@ def run_vdb_update_once() -> None:
         return
 
     logging.info("Updating VDB...")
+    vectorstore = app.state.vectorstore
+    collection_existed_before = vectorstore.client.collection_exists(QDRANT_COL)
+    initial_build_in_progress = not collection_existed_before
+    manifest = VDBManifest(QDRANT_META_PATH)
 
     try:
         start_time = time.time()
 
         questdb_pool = app.state.questdb_pool
-        embeddings = app.state.vectorstore.embeddings
+        embeddings = vectorstore.embeddings
         llm = app.state.llm
 
         # Get admin authenticated sources and update DB
@@ -213,6 +220,10 @@ def run_vdb_update_once() -> None:
         )
 
         build_vectordb_from_sources(llm, embeddings, sources)
+
+        if initial_build_in_progress:
+            manifest.set_initialized()
+            manifest.save()
 
         elapsed = time.time() - start_time
 
@@ -334,12 +345,39 @@ def build_sources_status(questdb_pool, user_id: str) -> dict[str, Any]:
         source for source in selected_sources if source in connected_set
     )
     vdb_indexing_active = os.path.isfile(VDB_LOCK)
+    vectorstore = getattr(app.state, "vectorstore", None)
+    manifest = VDBManifest(QDRANT_META_PATH)
+
+    try:
+        vdb_ready = bool(
+            vectorstore is not None
+            and vectorstore.client.collection_exists(QDRANT_COL)
+        )
+    except Exception:
+        logging.exception("Failed to determine Qdrant readiness")
+        vdb_ready = False
+
+    initial_build_completed = manifest.is_initialized()
+
+    if (
+        not initial_build_completed
+        and not vdb_indexing_active
+        and vdb_ready
+        and manifest.num_chunks() > 0
+    ):
+        manifest.set_initialized()
+        manifest.save()
+        initial_build_completed = True
 
     return {
         "connected_sources": connected_sources,
         "selected_sources": selected_connected_sources,
         "vdb_indexing_active": vdb_indexing_active,
-        "can_chat": len(selected_connected_sources) > 0 and vdb_indexing_active,
+        "can_chat": (
+            len(selected_connected_sources) > 0
+            and vdb_ready
+            and initial_build_completed
+        ),
     }
 
 
@@ -453,17 +491,19 @@ async def delete_chat(auth: AuthenticatedAuth, chat_id: str):
 
 async def _run_chat_turn(auth: AuthInfo, chat_id: str, query: str) -> dict[str, Any]:
     questdb_pool = app.state.questdb_pool
+    sources_status = build_sources_status(questdb_pool, auth.sub)
     sources = get_selected_authenticated_sources(questdb_pool, auth.sub)
-    if not sources:
+
+    if not sources_status["selected_sources"]:
         raise HTTPException(
             status_code=409,
             detail="Connect and select at least one source before chatting",
         )
 
-    if not os.path.isfile(VDB_LOCK):
+    if not sources_status["can_chat"]:
         raise HTTPException(
             status_code=409,
-            detail="VDB indexing is not enabled. Chat is unavailable until an administrator starts indexing.",
+            detail="Chat is unavailable until the initial source indexing finishes.",
         )
 
     metrics_actor = metrics_actor_from_auth(auth.sub, auth.role)

--- a/backend/src/connectors/manifest.py
+++ b/backend/src/connectors/manifest.py
@@ -18,6 +18,7 @@ def load_manifest(path):
         "total_chunks": 0, 
         "completed": {},
         "topics": False,
+        "initialized": False,
     }
 
 
@@ -87,3 +88,11 @@ class VDBManifest:
 
     def set_topics(self):
         self.manifest['topics'] = True
+
+
+    def is_initialized(self):
+        return self.manifest.get('initialized', False)
+
+
+    def set_initialized(self):
+        self.manifest['initialized'] = True

--- a/frontend/src/features/chat/api.ts
+++ b/frontend/src/features/chat/api.ts
@@ -1,6 +1,6 @@
-import { API_RESOURCE, BACKEND_URL } from '@/lib/api'
-import { useLogto } from '@logto/react'
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { API_RESOURCE, BACKEND_URL } from "@/lib/api";
+import { useLogto } from "@logto/react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type {
   ChatDetail,
   ChatSummary,
@@ -10,203 +10,212 @@ import type {
   SourceLoginInfo,
   SourcesStatus,
   VdbUpdateStatus,
-} from './types'
+} from "./types";
 
 export const chatQueryKeys = {
-  all: ['chat'] as const,
-  detail: (chatId: string) => ['chat', 'detail', chatId] as const,
-  list: ['chat', 'list'] as const,
-  sources: ['chat', 'sources'] as const,
-  vdbUpdate: ['chat', 'vdb-update'] as const,
-}
+  all: ["chat"] as const,
+  detail: (chatId: string) => ["chat", "detail", chatId] as const,
+  list: ["chat", "list"] as const,
+  sources: ["chat", "sources"] as const,
+  vdbUpdate: ["chat", "vdb-update"] as const,
+};
 
 export function useAuthorizedChatRequest() {
-  const { getAccessToken } = useLogto()
+  const { getAccessToken } = useLogto();
 
   return async function authorizedChatRequest<T>(
     path: string,
     init?: RequestInit,
   ) {
-    const token = await getAccessToken(API_RESOURCE)
+    const token = await getAccessToken(API_RESOURCE);
     if (!token) {
-      throw new Error('Missing access token')
+      throw new Error("Missing access token");
     }
 
-    const headers = new Headers(init?.headers)
-    headers.set('Authorization', `Bearer ${token}`)
-    headers.set('Content-Type', 'application/json')
+    const headers = new Headers(init?.headers);
+    headers.set("Authorization", `Bearer ${token}`);
+    headers.set("Content-Type", "application/json");
 
     const response = await fetch(`${BACKEND_URL}${path}`, {
       ...init,
       headers,
-    })
+    });
 
     if (!response.ok) {
       const payload = (await response.json().catch(() => null)) as {
-        detail?: string
-      } | null
-      throw new Error(payload?.detail ?? `Request failed (${response.status})`)
+        detail?: string;
+      } | null;
+      throw new Error(payload?.detail ?? `Request failed (${response.status})`);
     }
 
     if (response.status === 204) {
-      return undefined as T
+      return undefined as T;
     }
 
-    const responseText = await response.text()
+    const responseText = await response.text();
     if (!responseText) {
-      return undefined as T
+      return undefined as T;
     }
 
-    return JSON.parse(responseText) as T
-  }
+    return JSON.parse(responseText) as T;
+  };
 }
 
 export function useChatsQuery() {
-  const request = useAuthorizedChatRequest()
+  const request = useAuthorizedChatRequest();
 
   return useQuery({
     queryKey: chatQueryKeys.list,
-    queryFn: () => request<ChatSummary[]>('/chats'),
-  })
+    queryFn: () => request<ChatSummary[]>("/chats"),
+  });
 }
 
 export function useSourcesStatusQuery() {
-  const request = useAuthorizedChatRequest()
+  const request = useAuthorizedChatRequest();
 
   return useQuery({
     queryKey: chatQueryKeys.sources,
-    queryFn: () => request<SourcesStatus>('/sources/status'),
-  })
+    queryFn: () => request<SourcesStatus>("/sources/status"),
+    refetchInterval: (query) => {
+      const status = query.state.data;
+      return status?.vdb_indexing_active && !status.can_chat ? 5000 : false;
+    },
+  });
 }
 
 export function useSourceLoginInfoQuery(source: string) {
-  const request = useAuthorizedChatRequest()
+  const request = useAuthorizedChatRequest();
 
   return useQuery({
-    queryKey: [...chatQueryKeys.sources, 'login-info', source],
+    queryKey: [...chatQueryKeys.sources, "login-info", source],
     queryFn: () =>
       request<SourceLoginInfo>(
         `/sources/login-info?source=${encodeURIComponent(source)}`,
       ),
-  })
+  });
 }
 
 export function useVdbUpdateStatusQuery(enabled: boolean) {
-  const request = useAuthorizedChatRequest()
+  const request = useAuthorizedChatRequest();
 
   return useQuery({
     enabled,
     queryKey: chatQueryKeys.vdbUpdate,
-    queryFn: () => request<VdbUpdateStatus>('/vdb-update-status'),
-  })
+    queryFn: () => request<VdbUpdateStatus>("/vdb-update-status"),
+    refetchInterval: (query) => (query.state.data?.active ? 5000 : false),
+  });
 }
 
 export function useChatQuery(chatId?: string) {
-  const request = useAuthorizedChatRequest()
+  const request = useAuthorizedChatRequest();
 
   return useQuery({
     enabled: Boolean(chatId),
     queryKey: chatId
       ? chatQueryKeys.detail(chatId)
-      : ['chat', 'detail', 'empty'],
+      : ["chat", "detail", "empty"],
     queryFn: () => request<ChatDetail>(`/chats/${chatId}`),
-  })
+  });
 }
 
 export function useCreateChatMutation() {
-  const request = useAuthorizedChatRequest()
-  const queryClient = useQueryClient()
+  const request = useAuthorizedChatRequest();
+  const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (payload?: CreateChatInput) =>
-      request<ChatDetail>('/chats', {
+      request<ChatDetail>("/chats", {
         body: JSON.stringify(payload ?? {}),
-        method: 'POST',
+        method: "POST",
       }),
     onSuccess: (chat) => {
-      queryClient.setQueryData(chatQueryKeys.detail(chat.id), chat)
-      void queryClient.invalidateQueries({ queryKey: chatQueryKeys.list })
+      queryClient.setQueryData(chatQueryKeys.detail(chat.id), chat);
+      void queryClient.invalidateQueries({ queryKey: chatQueryKeys.list });
     },
-  })
+  });
 }
 
 export function useDeleteChatMutation() {
-  const request = useAuthorizedChatRequest()
-  const queryClient = useQueryClient()
+  const request = useAuthorizedChatRequest();
+  const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (chatId: string) =>
       request<void>(`/chats/${chatId}`, {
-        method: 'DELETE',
+        method: "DELETE",
       }),
     onSuccess: async (_result, chatId) => {
       queryClient.setQueryData<ChatSummary[] | undefined>(
         chatQueryKeys.list,
         (currentChats) =>
           currentChats?.filter((chat) => chat.id !== chatId) ?? currentChats,
-      )
-      queryClient.removeQueries({ queryKey: chatQueryKeys.detail(chatId) })
-      await queryClient.invalidateQueries({ queryKey: chatQueryKeys.list })
+      );
+      queryClient.removeQueries({ queryKey: chatQueryKeys.detail(chatId) });
+      await queryClient.invalidateQueries({ queryKey: chatQueryKeys.list });
     },
-  })
+  });
 }
 
 export function useSendMessageMutation() {
-  const request = useAuthorizedChatRequest()
+  const request = useAuthorizedChatRequest();
 
   return useMutation({
     mutationFn: ({ chatId, content }: SendMessageInput) =>
       request<SendMessageResult>(`/chats/${chatId}/messages`, {
         body: JSON.stringify({ content }),
-        method: 'POST',
+        method: "POST",
       }),
-  })
+  });
 }
 
 export function useStartVdbUpdateMutation() {
-  const request = useAuthorizedChatRequest()
-  const queryClient = useQueryClient()
+  const request = useAuthorizedChatRequest();
+  const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: () =>
-      request<void>('/start-vdb-update', {
-        method: 'POST',
+      request<void>("/start-vdb-update", {
+        method: "POST",
       }),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: chatQueryKeys.vdbUpdate })
-      await queryClient.invalidateQueries({ queryKey: chatQueryKeys.sources })
+      await queryClient.invalidateQueries({
+        queryKey: chatQueryKeys.vdbUpdate,
+      });
+      await queryClient.invalidateQueries({ queryKey: chatQueryKeys.sources });
     },
-  })
+  });
 }
 
 export function useStopVdbUpdateMutation() {
-  const request = useAuthorizedChatRequest()
-  const queryClient = useQueryClient()
+  const request = useAuthorizedChatRequest();
+  const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: () =>
-      request<void>('/stop-vdb-update', {
-        method: 'POST',
+      request<void>("/stop-vdb-update", {
+        method: "POST",
       }),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: chatQueryKeys.vdbUpdate })
-      await queryClient.invalidateQueries({ queryKey: chatQueryKeys.sources })
+      await queryClient.invalidateQueries({
+        queryKey: chatQueryKeys.vdbUpdate,
+      });
+      await queryClient.invalidateQueries({ queryKey: chatQueryKeys.sources });
     },
-  })
+  });
 }
 
 export function useUpdateSourcesSelectionMutation() {
-  const request = useAuthorizedChatRequest()
-  const queryClient = useQueryClient()
+  const request = useAuthorizedChatRequest();
+  const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (selectedSources: string[]) =>
-      request<SourcesStatus>('/sources/selection', {
+      request<SourcesStatus>("/sources/selection", {
         body: JSON.stringify({ selected_sources: selectedSources }),
-        method: 'PUT',
+        method: "PUT",
       }),
     onSuccess: (status) => {
-      queryClient.setQueryData(chatQueryKeys.sources, status)
+      queryClient.setQueryData(chatQueryKeys.sources, status);
     },
-  })
+  });
 }

--- a/frontend/src/features/chat/chat-page.test.tsx
+++ b/frontend/src/features/chat/chat-page.test.tsx
@@ -20,6 +20,10 @@ import {
 import { ChatPage } from "./chat-page";
 
 type ConversationRenderState = {
+  composerDisabled?: boolean;
+  composerHint?: string;
+  emptyDescription?: string;
+  emptyTitle?: string;
   isSending: boolean;
   pendingContent: string | null;
   persistedUserContents: string[];
@@ -92,7 +96,10 @@ vi.mock("./conversation-view", () => ({
   ConversationView: (props: {
     chat?: { messages?: Array<{ content: string; id: string; role: string }> };
     composerDisabled?: boolean;
+    composerHint?: string;
     composerValue: string;
+    emptyDescription?: string;
+    emptyTitle?: string;
     isSending?: boolean;
     onComposerChange: (value: string) => void;
     onSendMessage: () => void;
@@ -104,6 +111,10 @@ vi.mock("./conversation-view", () => ({
     ];
 
     conversationRenderStates.push({
+      composerDisabled: props.composerDisabled,
+      composerHint: props.composerHint,
+      emptyDescription: props.emptyDescription,
+      emptyTitle: props.emptyTitle,
       isSending: props.isSending ?? false,
       pendingContent: props.pendingMessage?.content ?? null,
       persistedUserContents: (props.chat?.messages ?? [])
@@ -165,6 +176,13 @@ const sourcesStatusChatReadyWhileIndexing = {
 const sourcesStatusSetupInProgress = {
   can_chat: false,
   vdb_indexing_active: true,
+  connected_sources: ["drive"],
+  selected_sources: ["drive"],
+};
+
+const sourcesStatusAwaitingFirstBuild = {
+  can_chat: false,
+  vdb_indexing_active: false,
   connected_sources: ["drive"],
   selected_sources: ["drive"],
 };
@@ -683,7 +701,68 @@ describe("ChatPage", () => {
 
     await waitFor(() => {
       expect(
-        (screen.getByLabelText("composer") as HTMLInputElement).disabled,
+        conversationRenderStates.some(
+          (state) =>
+            state.composerDisabled === true &&
+            state.composerHint === "composer.finishSetupHint" &&
+            state.emptyTitle === "empty.syncTitle" &&
+            state.emptyDescription === "empty.syncDescription",
+        ),
+      ).toBe(true);
+    });
+  });
+
+  it("asks to start the first VDB build before chat is enabled", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const requestUrl =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        const method = init?.method ?? "GET";
+
+        if (requestUrl.endsWith("/sources/status")) {
+          return jsonResponse(sourcesStatusAwaitingFirstBuild);
+        }
+
+        if (requestUrl.endsWith("/chats") && method === "GET") {
+          return jsonResponse([]);
+        }
+
+        throw new Error(`Unexpected request: ${method} ${requestUrl}`);
+      }),
+    );
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        mutations: { retry: false },
+        queries: { retry: false },
+      },
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ChatPage
+          onSelectChat={() => undefined}
+          user={{ role: "admin", sub: "user-1" }}
+        />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        conversationRenderStates.some(
+          (state) =>
+            state.composerDisabled === true &&
+            state.composerHint ===
+              "composer.disabledHintIndexingInactiveAdmin" &&
+            state.emptyTitle === "empty.indexingInactiveTitle" &&
+            state.emptyDescription ===
+              "empty.indexingInactiveDescriptionAdmin",
+        ),
       ).toBe(true);
     });
   });

--- a/frontend/src/features/chat/chat-page.test.tsx
+++ b/frontend/src/features/chat/chat-page.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   act,
   cleanup,
@@ -8,51 +8,58 @@ import {
   render,
   screen,
   waitFor,
-} from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test'
-import { ChatPage } from './chat-page'
+} from "@testing-library/react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vite-plus/test";
+import { ChatPage } from "./chat-page";
 
 type ConversationRenderState = {
-  isSending: boolean
-  pendingContent: string | null
-  persistedUserContents: string[]
-}
+  isSending: boolean;
+  pendingContent: string | null;
+  persistedUserContents: string[];
+};
 
-let conversationRenderStates: ConversationRenderState[] = []
+let conversationRenderStates: ConversationRenderState[] = [];
 
-vi.mock('next-intl', () => ({
-  useLocale: () => 'es',
+vi.mock("next-intl", () => ({
+  useLocale: () => "es",
   useTranslations: () => (key: string) => key,
-}))
+}));
 
-vi.mock('@logto/react', () => ({
+vi.mock("@logto/react", () => ({
   useLogto: () => ({
-    getAccessToken: vi.fn().mockResolvedValue('token'),
+    getAccessToken: vi.fn().mockResolvedValue("token"),
   }),
-}))
+}));
 
-vi.mock('@/components/error-state', () => ({
+vi.mock("@/components/error-state", () => ({
   ErrorState: () => null,
-}))
+}));
 
-vi.mock('@/components/ui/button', () => ({
+vi.mock("@/components/ui/button", () => ({
   Button: ({
     children,
     ...props
   }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
     <button {...props}>{children}</button>
   ),
-}))
+}));
 
-vi.mock('./chat-shell', () => ({
+vi.mock("./chat-shell", () => ({
   ChatShell: ({
     children,
     sidebar,
     headerActions,
   }: {
-    children: React.ReactNode
-    sidebar: React.ReactNode
-    headerActions: React.ReactNode
+    children: React.ReactNode;
+    sidebar: React.ReactNode;
+    headerActions: React.ReactNode;
   }) => (
     <div>
       {sidebar}
@@ -60,12 +67,12 @@ vi.mock('./chat-shell', () => ({
       {children}
     </div>
   ),
-}))
+}));
 
-vi.mock('./chat-sidebar', () => ({
+vi.mock("./chat-sidebar", () => ({
   ChatSidebar: (props: {
-    chats: Array<{ id: string; title: string }>
-    onDeleteChat: (chatId: string) => void
+    chats: Array<{ id: string; title: string }>;
+    onDeleteChat: (chatId: string) => void;
   }) => (
     <div>
       {props.chats.map((chat) => (
@@ -75,34 +82,34 @@ vi.mock('./chat-sidebar', () => ({
       ))}
     </div>
   ),
-}))
+}));
 
-vi.mock('./sources-panel', () => ({
+vi.mock("./sources-panel", () => ({
   SourcesPanel: () => null,
-}))
+}));
 
-vi.mock('./conversation-view', () => ({
+vi.mock("./conversation-view", () => ({
   ConversationView: (props: {
-    chat?: { messages?: Array<{ content: string; id: string; role: string }> }
-    composerDisabled?: boolean
-    composerValue: string
-    isSending?: boolean
-    onComposerChange: (value: string) => void
-    onSendMessage: () => void
-    pendingMessage?: { content: string; id: string }
+    chat?: { messages?: Array<{ content: string; id: string; role: string }> };
+    composerDisabled?: boolean;
+    composerValue: string;
+    isSending?: boolean;
+    onComposerChange: (value: string) => void;
+    onSendMessage: () => void;
+    pendingMessage?: { content: string; id: string };
   }) => {
     const messages = [
       ...(props.chat?.messages ?? []),
       ...(props.pendingMessage ? [props.pendingMessage] : []),
-    ]
+    ];
 
     conversationRenderStates.push({
       isSending: props.isSending ?? false,
       pendingContent: props.pendingMessage?.content ?? null,
       persistedUserContents: (props.chat?.messages ?? [])
-        .filter((message) => message.role === 'user')
+        .filter((message) => message.role === "user")
         .map((message) => message.content),
-    })
+    });
 
     return (
       <div>
@@ -119,635 +126,783 @@ vi.mock('./conversation-view', () => ({
           <div key={message.id}>{message.content}</div>
         ))}
       </div>
-    )
+    );
   },
-}))
+}));
 
 function createDeferred<T>() {
-  let resolve!: (value: T | PromiseLike<T>) => void
+  let resolve!: (value: T | PromiseLike<T>) => void;
 
   const promise = new Promise<T>((resolvePromise) => {
-    resolve = resolvePromise
-  })
+    resolve = resolvePromise;
+  });
 
-  return { promise, resolve }
+  return { promise, resolve };
 }
 
 function jsonResponse(payload: unknown) {
   return new Response(JSON.stringify(payload), {
-    headers: { 'Content-Type': 'application/json' },
+    headers: { "Content-Type": "application/json" },
     status: 200,
-  })
+  });
 }
 
 /** Sources + VDB state that allows sending chat messages (matches backend contract). */
 const sourcesStatusChatReady = {
   can_chat: true,
-  vdb_indexing_active: true,
-  connected_sources: ['drive'],
-  selected_sources: ['drive'],
-}
+  vdb_indexing_active: false,
+  connected_sources: ["drive"],
+  selected_sources: ["drive"],
+};
 
-describe('ChatPage', () => {
+const sourcesStatusChatReadyWhileIndexing = {
+  can_chat: true,
+  vdb_indexing_active: true,
+  connected_sources: ["drive"],
+  selected_sources: ["drive"],
+};
+
+const sourcesStatusSetupInProgress = {
+  can_chat: false,
+  vdb_indexing_active: true,
+  connected_sources: ["drive"],
+  selected_sources: ["drive"],
+};
+
+describe("ChatPage", () => {
   beforeEach(() => {
-    conversationRenderStates = []
-  })
+    conversationRenderStates = [];
+  });
 
   afterEach(() => {
-    cleanup()
-    vi.restoreAllMocks()
-  })
+    cleanup();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
 
-  it('does not render the pending user message alongside the persisted one', async () => {
-    const sendResponse = createDeferred<Response>()
+  it("does not render the pending user message alongside the persisted one", async () => {
+    const sendResponse = createDeferred<Response>();
 
     vi.stubGlobal(
-      'fetch',
+      "fetch",
       vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
         const requestUrl =
-          typeof input === 'string'
+          typeof input === "string"
             ? input
             : input instanceof URL
               ? input.toString()
-              : input.url
-        const method = init?.method ?? 'GET'
+              : input.url;
+        const method = init?.method ?? "GET";
 
-        if (requestUrl.endsWith('/sources/status')) {
-          return jsonResponse(sourcesStatusChatReady)
+        if (requestUrl.endsWith("/sources/status")) {
+          return jsonResponse(sourcesStatusChatReady);
         }
 
-        if (requestUrl.endsWith('/chats') && method === 'GET') {
-          return jsonResponse([])
+        if (requestUrl.endsWith("/chats") && method === "GET") {
+          return jsonResponse([]);
         }
 
-        if (requestUrl.endsWith('/chats/chat-1') && method === 'GET') {
+        if (requestUrl.endsWith("/chats/chat-1") && method === "GET") {
           return jsonResponse({
-            created_at: '2026-04-14T18:30:00.000Z',
-            id: 'chat-1',
+            created_at: "2026-04-14T18:30:00.000Z",
+            id: "chat-1",
             last_message_preview: null,
             messages: [],
-            title: 'Chat empresarial',
-            updated_at: '2026-04-14T18:30:00.000Z',
-          })
+            title: "Chat empresarial",
+            updated_at: "2026-04-14T18:30:00.000Z",
+          });
         }
 
         if (
-          requestUrl.endsWith('/chats/chat-1/messages') &&
-          method === 'POST'
+          requestUrl.endsWith("/chats/chat-1/messages") &&
+          method === "POST"
         ) {
-          return sendResponse.promise
+          return sendResponse.promise;
         }
 
-        throw new Error(`Unexpected request: ${method} ${requestUrl}`)
+        throw new Error(`Unexpected request: ${method} ${requestUrl}`);
       }),
-    )
+    );
 
     const queryClient = new QueryClient({
       defaultOptions: {
         mutations: { retry: false },
         queries: { retry: false },
       },
-    })
+    });
 
     render(
       <QueryClientProvider client={queryClient}>
         <ChatPage
           onSelectChat={() => undefined}
           selectedChatId="chat-1"
-          user={{ role: 'user', sub: 'user-1' }}
+          user={{ role: "user", sub: "user-1" }}
         />
       </QueryClientProvider>,
-    )
+    );
 
-    await screen.findByLabelText('composer')
+    await screen.findByLabelText("composer");
 
-    fireEvent.change(screen.getByLabelText('composer'), {
-      target: { value: 'dime como pedir vacaciones' },
-    })
-    fireEvent.click(screen.getByText('send'))
+    fireEvent.change(screen.getByLabelText("composer"), {
+      target: { value: "dime como pedir vacaciones" },
+    });
+    fireEvent.click(screen.getByText("send"));
 
     await waitFor(() => {
-      expect(screen.getAllByText('dime como pedir vacaciones')).toHaveLength(1)
-    })
+      expect(screen.getAllByText("dime como pedir vacaciones")).toHaveLength(1);
+    });
 
     sendResponse.resolve(
       jsonResponse({
         assistant_message: {
-          chat_id: 'chat-1',
-          content: 'Consulta el portal interno de RRHH.',
-          created_at: '2026-04-14T18:31:02.000Z',
-          id: 'assistant-1',
+          chat_id: "chat-1",
+          content: "Consulta el portal interno de RRHH.",
+          created_at: "2026-04-14T18:31:02.000Z",
+          id: "assistant-1",
           metadata: null,
-          role: 'assistant',
+          role: "assistant",
           status: null,
         },
         chat: {
-          created_at: '2026-04-14T18:30:00.000Z',
-          id: 'chat-1',
-          last_message_preview: 'Consulta el portal interno de RRHH.',
+          created_at: "2026-04-14T18:30:00.000Z",
+          id: "chat-1",
+          last_message_preview: "Consulta el portal interno de RRHH.",
           messages: [
             {
-              chat_id: 'chat-1',
-              content: 'dime como pedir vacaciones',
-              created_at: '2026-04-14T18:31:00.000Z',
-              id: 'user-1',
+              chat_id: "chat-1",
+              content: "dime como pedir vacaciones",
+              created_at: "2026-04-14T18:31:00.000Z",
+              id: "user-1",
               metadata: null,
-              role: 'user',
+              role: "user",
               status: null,
             },
             {
-              chat_id: 'chat-1',
-              content: 'Consulta el portal interno de RRHH.',
-              created_at: '2026-04-14T18:31:02.000Z',
-              id: 'assistant-1',
+              chat_id: "chat-1",
+              content: "Consulta el portal interno de RRHH.",
+              created_at: "2026-04-14T18:31:02.000Z",
+              id: "assistant-1",
               metadata: null,
-              role: 'assistant',
+              role: "assistant",
               status: null,
             },
           ],
-          title: 'Chat empresarial',
-          updated_at: '2026-04-14T18:31:02.000Z',
+          title: "Chat empresarial",
+          updated_at: "2026-04-14T18:31:02.000Z",
         },
-        detected_lang: 'es',
+        detected_lang: "es",
         user_message: {
-          chat_id: 'chat-1',
-          content: 'dime como pedir vacaciones',
-          created_at: '2026-04-14T18:31:00.000Z',
-          id: 'user-1',
+          chat_id: "chat-1",
+          content: "dime como pedir vacaciones",
+          created_at: "2026-04-14T18:31:00.000Z",
+          id: "user-1",
           metadata: null,
-          role: 'user',
+          role: "user",
           status: null,
         },
       }),
-    )
+    );
 
     await waitFor(() => {
-      expect(screen.getByTestId('message-count').textContent).toBe('2')
-    })
+      expect(screen.getByTestId("message-count").textContent).toBe("2");
+    });
 
     expect(
       conversationRenderStates.some(
         (state) =>
-          state.pendingContent === 'dime como pedir vacaciones' &&
-          state.persistedUserContents.includes('dime como pedir vacaciones'),
+          state.pendingContent === "dime como pedir vacaciones" &&
+          state.persistedUserContents.includes("dime como pedir vacaciones"),
       ),
-    ).toBe(false)
-  })
+    ).toBe(false);
+  });
 
-  it('keeps the pending user message scoped to the originating chat', async () => {
-    const sendResponse = createDeferred<Response>()
+  it("keeps the pending user message scoped to the originating chat", async () => {
+    const sendResponse = createDeferred<Response>();
 
     vi.stubGlobal(
-      'fetch',
+      "fetch",
       vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
         const requestUrl =
-          typeof input === 'string'
+          typeof input === "string"
             ? input
             : input instanceof URL
               ? input.toString()
-              : input.url
-        const method = init?.method ?? 'GET'
+              : input.url;
+        const method = init?.method ?? "GET";
 
-        if (requestUrl.endsWith('/sources/status')) {
-          return jsonResponse(sourcesStatusChatReady)
+        if (requestUrl.endsWith("/sources/status")) {
+          return jsonResponse(sourcesStatusChatReady);
         }
 
-        if (requestUrl.endsWith('/chats') && method === 'GET') {
+        if (requestUrl.endsWith("/chats") && method === "GET") {
           return jsonResponse([
             {
-              created_at: '2026-04-14T18:30:00.000Z',
-              id: 'chat-1',
+              created_at: "2026-04-14T18:30:00.000Z",
+              id: "chat-1",
               last_message_preview: null,
-              title: 'Chat empresarial',
-              updated_at: '2026-04-14T18:30:00.000Z',
+              title: "Chat empresarial",
+              updated_at: "2026-04-14T18:30:00.000Z",
             },
             {
-              created_at: '2026-04-14T18:20:00.000Z',
-              id: 'chat-2',
+              created_at: "2026-04-14T18:20:00.000Z",
+              id: "chat-2",
               last_message_preview: null,
-              title: 'Chat de soporte',
-              updated_at: '2026-04-14T18:20:00.000Z',
+              title: "Chat de soporte",
+              updated_at: "2026-04-14T18:20:00.000Z",
             },
-          ])
+          ]);
         }
 
-        if (requestUrl.endsWith('/chats/chat-1') && method === 'GET') {
+        if (requestUrl.endsWith("/chats/chat-1") && method === "GET") {
           return jsonResponse({
-            created_at: '2026-04-14T18:30:00.000Z',
-            id: 'chat-1',
+            created_at: "2026-04-14T18:30:00.000Z",
+            id: "chat-1",
             last_message_preview: null,
             messages: [],
-            title: 'Chat empresarial',
-            updated_at: '2026-04-14T18:30:00.000Z',
-          })
+            title: "Chat empresarial",
+            updated_at: "2026-04-14T18:30:00.000Z",
+          });
         }
 
-        if (requestUrl.endsWith('/chats/chat-2') && method === 'GET') {
+        if (requestUrl.endsWith("/chats/chat-2") && method === "GET") {
           return jsonResponse({
-            created_at: '2026-04-14T18:20:00.000Z',
-            id: 'chat-2',
+            created_at: "2026-04-14T18:20:00.000Z",
+            id: "chat-2",
             last_message_preview: null,
             messages: [],
-            title: 'Chat de soporte',
-            updated_at: '2026-04-14T18:20:00.000Z',
-          })
+            title: "Chat de soporte",
+            updated_at: "2026-04-14T18:20:00.000Z",
+          });
         }
 
         if (
-          requestUrl.endsWith('/chats/chat-1/messages') &&
-          method === 'POST'
+          requestUrl.endsWith("/chats/chat-1/messages") &&
+          method === "POST"
         ) {
-          return sendResponse.promise
+          return sendResponse.promise;
         }
 
-        throw new Error(`Unexpected request: ${method} ${requestUrl}`)
+        throw new Error(`Unexpected request: ${method} ${requestUrl}`);
       }),
-    )
+    );
 
     const queryClient = new QueryClient({
       defaultOptions: {
         mutations: { retry: false },
         queries: { retry: false },
       },
-    })
+    });
 
     const { rerender } = render(
       <QueryClientProvider client={queryClient}>
         <ChatPage
           onSelectChat={() => undefined}
           selectedChatId="chat-1"
-          user={{ role: 'user', sub: 'user-1' }}
+          user={{ role: "user", sub: "user-1" }}
         />
       </QueryClientProvider>,
-    )
+    );
 
-    await screen.findByLabelText('composer')
+    await screen.findByLabelText("composer");
 
-    fireEvent.change(screen.getByLabelText('composer'), {
-      target: { value: 'mensaje en curso' },
-    })
-    fireEvent.click(screen.getByText('send'))
+    fireEvent.change(screen.getByLabelText("composer"), {
+      target: { value: "mensaje en curso" },
+    });
+    fireEvent.click(screen.getByText("send"));
 
     await waitFor(() => {
-      expect(screen.getAllByText('mensaje en curso')).toHaveLength(1)
-    })
-    expect(screen.getByText('sending-indicator')).toBeTruthy()
+      expect(screen.getAllByText("mensaje en curso")).toHaveLength(1);
+    });
+    expect(screen.getByText("sending-indicator")).toBeTruthy();
 
     rerender(
       <QueryClientProvider client={queryClient}>
         <ChatPage
           onSelectChat={() => undefined}
           selectedChatId="chat-2"
-          user={{ role: 'user', sub: 'user-1' }}
+          user={{ role: "user", sub: "user-1" }}
         />
       </QueryClientProvider>,
-    )
+    );
 
     await waitFor(() => {
-      expect(screen.queryByText('mensaje en curso')).toBeNull()
-    })
-    expect(screen.queryByText('sending-indicator')).toBeNull()
-    expect(conversationRenderStates.at(-1)?.isSending).toBe(false)
+      expect(screen.queryByText("mensaje en curso")).toBeNull();
+    });
+    expect(screen.queryByText("sending-indicator")).toBeNull();
+    expect(conversationRenderStates.at(-1)?.isSending).toBe(false);
 
     sendResponse.resolve(
       jsonResponse({
         assistant_message: {
-          chat_id: 'chat-1',
-          content: 'respuesta final',
-          created_at: '2026-04-14T18:31:02.000Z',
-          id: 'assistant-1',
+          chat_id: "chat-1",
+          content: "respuesta final",
+          created_at: "2026-04-14T18:31:02.000Z",
+          id: "assistant-1",
           metadata: null,
-          role: 'assistant',
+          role: "assistant",
           status: null,
         },
         chat: {
-          created_at: '2026-04-14T18:30:00.000Z',
-          id: 'chat-1',
-          last_message_preview: 'respuesta final',
+          created_at: "2026-04-14T18:30:00.000Z",
+          id: "chat-1",
+          last_message_preview: "respuesta final",
           messages: [
             {
-              chat_id: 'chat-1',
-              content: 'mensaje en curso',
-              created_at: '2026-04-14T18:31:00.000Z',
-              id: 'user-1',
+              chat_id: "chat-1",
+              content: "mensaje en curso",
+              created_at: "2026-04-14T18:31:00.000Z",
+              id: "user-1",
               metadata: null,
-              role: 'user',
+              role: "user",
               status: null,
             },
             {
-              chat_id: 'chat-1',
-              content: 'respuesta final',
-              created_at: '2026-04-14T18:31:02.000Z',
-              id: 'assistant-1',
+              chat_id: "chat-1",
+              content: "respuesta final",
+              created_at: "2026-04-14T18:31:02.000Z",
+              id: "assistant-1",
               metadata: null,
-              role: 'assistant',
+              role: "assistant",
               status: null,
             },
           ],
-          title: 'Chat empresarial',
-          updated_at: '2026-04-14T18:31:02.000Z',
+          title: "Chat empresarial",
+          updated_at: "2026-04-14T18:31:02.000Z",
         },
-        detected_lang: 'es',
+        detected_lang: "es",
         user_message: {
-          chat_id: 'chat-1',
-          content: 'mensaje en curso',
-          created_at: '2026-04-14T18:31:00.000Z',
-          id: 'user-1',
+          chat_id: "chat-1",
+          content: "mensaje en curso",
+          created_at: "2026-04-14T18:31:00.000Z",
+          id: "user-1",
           metadata: null,
-          role: 'user',
+          role: "user",
           status: null,
         },
       }),
-    )
+    );
 
     await waitFor(() => {
-      expect(screen.queryByText('mensaje en curso')).toBeNull()
-    })
-  })
+      expect(screen.queryByText("mensaje en curso")).toBeNull();
+    });
+  });
 
-  it('hides the optimistic bubble once the chat query contains the persisted user message', async () => {
-    const sendResponse = createDeferred<Response>()
+  it("hides the optimistic bubble once the chat query contains the persisted user message", async () => {
+    const sendResponse = createDeferred<Response>();
 
     vi.stubGlobal(
-      'fetch',
+      "fetch",
       vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
         const requestUrl =
-          typeof input === 'string'
+          typeof input === "string"
             ? input
             : input instanceof URL
               ? input.toString()
-              : input.url
-        const method = init?.method ?? 'GET'
+              : input.url;
+        const method = init?.method ?? "GET";
 
-        if (requestUrl.endsWith('/sources/status')) {
-          return jsonResponse(sourcesStatusChatReady)
+        if (requestUrl.endsWith("/sources/status")) {
+          return jsonResponse(sourcesStatusChatReady);
         }
 
-        if (requestUrl.endsWith('/chats') && method === 'GET') {
-          return jsonResponse([])
+        if (requestUrl.endsWith("/chats") && method === "GET") {
+          return jsonResponse([]);
         }
 
-        if (requestUrl.endsWith('/chats/chat-1') && method === 'GET') {
+        if (requestUrl.endsWith("/chats/chat-1") && method === "GET") {
           return jsonResponse({
-            created_at: '2026-04-14T18:30:00.000Z',
-            id: 'chat-1',
+            created_at: "2026-04-14T18:30:00.000Z",
+            id: "chat-1",
             last_message_preview: null,
             messages: [],
-            title: 'Chat empresarial',
-            updated_at: '2026-04-14T18:30:00.000Z',
-          })
+            title: "Chat empresarial",
+            updated_at: "2026-04-14T18:30:00.000Z",
+          });
         }
 
         if (
-          requestUrl.endsWith('/chats/chat-1/messages') &&
-          method === 'POST'
+          requestUrl.endsWith("/chats/chat-1/messages") &&
+          method === "POST"
         ) {
-          return sendResponse.promise
+          return sendResponse.promise;
         }
 
-        throw new Error(`Unexpected request: ${method} ${requestUrl}`)
+        throw new Error(`Unexpected request: ${method} ${requestUrl}`);
       }),
-    )
+    );
 
     const queryClient = new QueryClient({
       defaultOptions: {
         mutations: { retry: false },
         queries: { retry: false },
       },
-    })
+    });
 
     render(
       <QueryClientProvider client={queryClient}>
         <ChatPage
           onSelectChat={() => undefined}
           selectedChatId="chat-1"
-          user={{ role: 'user', sub: 'user-1' }}
+          user={{ role: "user", sub: "user-1" }}
         />
       </QueryClientProvider>,
-    )
+    );
 
-    await screen.findByLabelText('composer')
+    await screen.findByLabelText("composer");
 
-    fireEvent.change(screen.getByLabelText('composer'), {
-      target: { value: 'mensaje duplicado' },
-    })
-    fireEvent.click(screen.getByText('send'))
+    fireEvent.change(screen.getByLabelText("composer"), {
+      target: { value: "mensaje duplicado" },
+    });
+    fireEvent.click(screen.getByText("send"));
 
     await waitFor(() => {
-      expect(screen.getAllByText('mensaje duplicado')).toHaveLength(1)
-    })
+      expect(screen.getAllByText("mensaje duplicado")).toHaveLength(1);
+    });
 
     act(() => {
-      queryClient.setQueryData(['chat', 'detail', 'chat-1'], {
-        created_at: '2026-04-14T18:30:00.000Z',
-        id: 'chat-1',
-        last_message_preview: 'mensaje duplicado',
+      queryClient.setQueryData(["chat", "detail", "chat-1"], {
+        created_at: "2026-04-14T18:30:00.000Z",
+        id: "chat-1",
+        last_message_preview: "mensaje duplicado",
         messages: [
           {
-            chat_id: 'chat-1',
-            content: 'mensaje duplicado',
-            created_at: '2026-04-14T18:30:59.000Z',
-            id: 'user-1',
+            chat_id: "chat-1",
+            content: "mensaje duplicado",
+            created_at: "2026-04-14T18:30:59.000Z",
+            id: "user-1",
             metadata: null,
-            role: 'user',
+            role: "user",
             status: null,
           },
         ],
-        title: 'Chat empresarial',
-        updated_at: '2026-04-14T18:31:01.000Z',
-      })
-    })
+        title: "Chat empresarial",
+        updated_at: "2026-04-14T18:31:01.000Z",
+      });
+    });
 
     await waitFor(() => {
-      expect(screen.getAllByText('mensaje duplicado')).toHaveLength(1)
-      expect(screen.getByTestId('message-count').textContent).toBe('1')
-    })
+      expect(screen.getAllByText("mensaje duplicado")).toHaveLength(1);
+      expect(screen.getByTestId("message-count").textContent).toBe("1");
+    });
 
     sendResponse.resolve(
       jsonResponse({
         assistant_message: {
-          chat_id: 'chat-1',
-          content: 'respuesta final',
-          created_at: '2026-04-14T18:31:02.000Z',
-          id: 'assistant-1',
+          chat_id: "chat-1",
+          content: "respuesta final",
+          created_at: "2026-04-14T18:31:02.000Z",
+          id: "assistant-1",
           metadata: null,
-          role: 'assistant',
+          role: "assistant",
           status: null,
         },
         chat: {
-          created_at: '2026-04-14T18:30:00.000Z',
-          id: 'chat-1',
-          last_message_preview: 'respuesta final',
+          created_at: "2026-04-14T18:30:00.000Z",
+          id: "chat-1",
+          last_message_preview: "respuesta final",
           messages: [
             {
-              chat_id: 'chat-1',
-              content: 'mensaje duplicado',
-              created_at: '2026-04-14T18:31:01.000Z',
-              id: 'user-1',
+              chat_id: "chat-1",
+              content: "mensaje duplicado",
+              created_at: "2026-04-14T18:31:01.000Z",
+              id: "user-1",
               metadata: null,
-              role: 'user',
+              role: "user",
               status: null,
             },
             {
-              chat_id: 'chat-1',
-              content: 'respuesta final',
-              created_at: '2026-04-14T18:31:02.000Z',
-              id: 'assistant-1',
+              chat_id: "chat-1",
+              content: "respuesta final",
+              created_at: "2026-04-14T18:31:02.000Z",
+              id: "assistant-1",
               metadata: null,
-              role: 'assistant',
+              role: "assistant",
               status: null,
             },
           ],
-          title: 'Chat empresarial',
-          updated_at: '2026-04-14T18:31:02.000Z',
+          title: "Chat empresarial",
+          updated_at: "2026-04-14T18:31:02.000Z",
         },
-        detected_lang: 'es',
+        detected_lang: "es",
         user_message: {
-          chat_id: 'chat-1',
-          content: 'mensaje duplicado',
-          created_at: '2026-04-14T18:31:01.000Z',
-          id: 'user-1',
+          chat_id: "chat-1",
+          content: "mensaje duplicado",
+          created_at: "2026-04-14T18:31:01.000Z",
+          id: "user-1",
           metadata: null,
-          role: 'user',
+          role: "user",
           status: null,
         },
       }),
-    )
+    );
 
     await waitFor(() => {
-      expect(screen.getByTestId('message-count').textContent).toBe('2')
-    })
-  })
+      expect(screen.getByTestId("message-count").textContent).toBe("2");
+    });
+  });
 
-  it('keeps chat enabled for admins while VDB indexing is active', async () => {
+  it("disables chat while the first VDB build is still in progress", async () => {
     vi.stubGlobal(
-      'fetch',
+      "fetch",
       vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
         const requestUrl =
-          typeof input === 'string'
+          typeof input === "string"
             ? input
             : input instanceof URL
               ? input.toString()
-              : input.url
-        const method = init?.method ?? 'GET'
+              : input.url;
+        const method = init?.method ?? "GET";
 
-        if (requestUrl.endsWith('/sources/status')) {
-          return jsonResponse(sourcesStatusChatReady)
+        if (requestUrl.endsWith("/sources/status")) {
+          return jsonResponse(sourcesStatusSetupInProgress);
         }
 
-        if (requestUrl.endsWith('/vdb-update-status')) {
-          return jsonResponse({ active: true })
+        if (requestUrl.endsWith("/chats") && method === "GET") {
+          return jsonResponse([]);
         }
 
-        if (requestUrl.endsWith('/chats') && method === 'GET') {
-          return jsonResponse([])
-        }
-
-        throw new Error(`Unexpected request: ${method} ${requestUrl}`)
+        throw new Error(`Unexpected request: ${method} ${requestUrl}`);
       }),
-    )
+    );
 
     const queryClient = new QueryClient({
       defaultOptions: {
         mutations: { retry: false },
         queries: { retry: false },
       },
-    })
+    });
 
     render(
       <QueryClientProvider client={queryClient}>
         <ChatPage
           onSelectChat={() => undefined}
-          user={{ role: 'admin', sub: 'user-1' }}
+          user={{ role: "admin", sub: "user-1" }}
         />
       </QueryClientProvider>,
-    )
+    );
 
     await waitFor(() => {
       expect(
-        (screen.getByLabelText('composer') as HTMLInputElement).disabled,
-      ).toBe(false)
-    })
-  })
+        (screen.getByLabelText("composer") as HTMLInputElement).disabled,
+      ).toBe(true);
+    });
+  });
 
-  it('selects the next chat after deleting the active conversation', async () => {
-    let chats = [
-      {
-        created_at: '2026-04-14T18:30:00.000Z',
-        id: 'chat-1',
-        last_message_preview: 'Mensaje 1',
-        title: 'Chat empresarial',
-        updated_at: '2026-04-14T18:32:00.000Z',
-      },
-      {
-        created_at: '2026-04-14T18:20:00.000Z',
-        id: 'chat-2',
-        last_message_preview: 'Mensaje 2',
-        title: 'Chat de soporte',
-        updated_at: '2026-04-14T18:21:00.000Z',
-      },
-    ]
-
-    const onSelectChat = vi.fn()
-
+  it("keeps chat enabled while indexing continues after the first build", async () => {
     vi.stubGlobal(
-      'fetch',
+      "fetch",
       vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
         const requestUrl =
-          typeof input === 'string'
+          typeof input === "string"
             ? input
             : input instanceof URL
               ? input.toString()
-              : input.url
-        const method = init?.method ?? 'GET'
+              : input.url;
+        const method = init?.method ?? "GET";
 
-        if (requestUrl.endsWith('/sources/status')) {
-          return jsonResponse(sourcesStatusChatReady)
+        if (requestUrl.endsWith("/sources/status")) {
+          return jsonResponse(sourcesStatusChatReadyWhileIndexing);
         }
 
-        if (requestUrl.endsWith('/chats') && method === 'GET') {
-          return jsonResponse(chats)
+        if (requestUrl.endsWith("/chats") && method === "GET") {
+          return jsonResponse([]);
         }
 
-        if (requestUrl.endsWith('/chats/chat-1') && method === 'GET') {
-          return jsonResponse({
-            ...chats[0],
-            messages: [],
-          })
-        }
-
-        if (requestUrl.endsWith('/chats/chat-1') && method === 'DELETE') {
-          chats = chats.filter((chat) => chat.id !== 'chat-1')
-          return new Response(null, { status: 204 })
-        }
-
-        throw new Error(`Unexpected request: ${method} ${requestUrl}`)
+        throw new Error(`Unexpected request: ${method} ${requestUrl}`);
       }),
-    )
+    );
 
     const queryClient = new QueryClient({
       defaultOptions: {
         mutations: { retry: false },
         queries: { retry: false },
       },
-    })
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ChatPage
+          onSelectChat={() => undefined}
+          user={{ role: "admin", sub: "user-1" }}
+        />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        (screen.getByLabelText("composer") as HTMLInputElement).disabled,
+      ).toBe(false);
+    });
+  });
+
+  it("re-enables chat automatically after the initial VDB build finishes", async () => {
+    vi.useFakeTimers();
+
+    let statusResponse = sourcesStatusSetupInProgress;
+    const fetchMock = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const requestUrl =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        const method = init?.method ?? "GET";
+
+        if (requestUrl.endsWith("/sources/status")) {
+          return jsonResponse(statusResponse);
+        }
+
+        if (requestUrl.endsWith("/chats") && method === "GET") {
+          return jsonResponse([]);
+        }
+
+        throw new Error(`Unexpected request: ${method} ${requestUrl}`);
+      },
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        mutations: { retry: false },
+        queries: { retry: false },
+      },
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ChatPage
+          onSelectChat={() => undefined}
+          user={{ role: "admin", sub: "user-1" }}
+        />
+      </QueryClientProvider>,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(
+      (screen.getByLabelText("composer") as HTMLInputElement).disabled,
+    ).toBe(true);
+
+    const initialSourcesStatusCalls = fetchMock.mock.calls.filter(([input]) => {
+      const requestUrl =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      return requestUrl.endsWith("/sources/status");
+    }).length;
+
+    statusResponse = sourcesStatusChatReady;
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10000);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const updatedSourcesStatusCalls = fetchMock.mock.calls.filter(([input]) => {
+      const requestUrl =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      return requestUrl.endsWith("/sources/status");
+    }).length;
+
+    expect(updatedSourcesStatusCalls).toBeGreaterThan(
+      initialSourcesStatusCalls,
+    );
+
+    expect(
+      (screen.getByLabelText("composer") as HTMLInputElement).disabled,
+    ).toBe(false);
+  });
+
+  it("selects the next chat after deleting the active conversation", async () => {
+    let chats = [
+      {
+        created_at: "2026-04-14T18:30:00.000Z",
+        id: "chat-1",
+        last_message_preview: "Mensaje 1",
+        title: "Chat empresarial",
+        updated_at: "2026-04-14T18:32:00.000Z",
+      },
+      {
+        created_at: "2026-04-14T18:20:00.000Z",
+        id: "chat-2",
+        last_message_preview: "Mensaje 2",
+        title: "Chat de soporte",
+        updated_at: "2026-04-14T18:21:00.000Z",
+      },
+    ];
+
+    const onSelectChat = vi.fn();
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const requestUrl =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        const method = init?.method ?? "GET";
+
+        if (requestUrl.endsWith("/sources/status")) {
+          return jsonResponse(sourcesStatusChatReady);
+        }
+
+        if (requestUrl.endsWith("/chats") && method === "GET") {
+          return jsonResponse(chats);
+        }
+
+        if (requestUrl.endsWith("/chats/chat-1") && method === "GET") {
+          return jsonResponse({
+            ...chats[0],
+            messages: [],
+          });
+        }
+
+        if (requestUrl.endsWith("/chats/chat-1") && method === "DELETE") {
+          chats = chats.filter((chat) => chat.id !== "chat-1");
+          return new Response(null, { status: 204 });
+        }
+
+        throw new Error(`Unexpected request: ${method} ${requestUrl}`);
+      }),
+    );
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        mutations: { retry: false },
+        queries: { retry: false },
+      },
+    });
 
     render(
       <QueryClientProvider client={queryClient}>
         <ChatPage
           onSelectChat={onSelectChat}
           selectedChatId="chat-1"
-          user={{ role: 'user', sub: 'user-1' }}
+          user={{ role: "user", sub: "user-1" }}
         />
       </QueryClientProvider>,
-    )
+    );
 
-    await screen.findByText('delete-chat-1')
+    await screen.findByText("delete-chat-1");
 
-    fireEvent.click(screen.getByText('delete-chat-1'))
+    fireEvent.click(screen.getByText("delete-chat-1"));
 
     await waitFor(() => {
-      expect(onSelectChat).toHaveBeenCalledWith('chat-2', { replace: true })
-    })
-  })
-})
+      expect(onSelectChat).toHaveBeenCalledWith("chat-2", { replace: true });
+    });
+  });
+});

--- a/frontend/src/features/chat/chat-page.test.tsx
+++ b/frontend/src/features/chat/chat-page.test.tsx
@@ -195,6 +195,7 @@ describe("ChatPage", () => {
   afterEach(() => {
     cleanup();
     vi.useRealTimers();
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 

--- a/frontend/src/features/chat/chat-page.tsx
+++ b/frontend/src/features/chat/chat-page.tsx
@@ -95,12 +95,16 @@ export function ChatPage({
   const hasSelectedSource = (sourcesStatus?.selected_sources?.length ?? 0) > 0;
   const vdbIndexingActive = sourcesStatus?.vdb_indexing_active ?? false;
   const chatEnabled = sourcesStatus?.can_chat ?? false;
+  const setupInProgress =
+    hasSelectedSource && vdbIndexingActive && !chatEnabled;
   const composerDisabled = !chatEnabled;
 
   let composerHint: string | undefined;
   if (!chatEnabled && sourcesStatus) {
     if (!hasSelectedSource) {
       composerHint = t("composer.disabledHint");
+    } else if (setupInProgress) {
+      composerHint = t("composer.finishSetupHint");
     } else if (!vdbIndexingActive) {
       composerHint =
         user.role === "admin"
@@ -115,7 +119,10 @@ export function ChatPage({
 
   if (!chatEnabled) {
     emptyPrimaryActionLabel = t("sources.openPanel");
-    if (sourcesStatus && hasSelectedSource && !vdbIndexingActive) {
+    if (setupInProgress) {
+      emptyTitle = t("empty.syncTitle");
+      emptyDescription = t("empty.syncDescription");
+    } else if (sourcesStatus && hasSelectedSource && !vdbIndexingActive) {
       emptyTitle = t("empty.indexingInactiveTitle");
       emptyDescription =
         user.role === "admin"

--- a/frontend/src/i18n/messages/en.json
+++ b/frontend/src/i18n/messages/en.json
@@ -294,18 +294,18 @@
       "description": "Choose an existing conversation or start a new one to chat with the assistant.",
       "gatedTitle": "Connect and select at least one source",
       "gatedDescription": "Open the sources panel to start the source setup flow before starting the conversation.",
-      "indexingInactiveTitle": "Indexing is not enabled yet",
-      "indexingInactiveDescriptionAdmin": "Open the sources panel and start VDB indexing when your connected sources are selected for retrieval.",
-      "indexingInactiveDescriptionUser": "Open the sources panel and ask an administrator to start VDB indexing when your connected sources are ready.",
-      "syncTitle": "Finish source setup before chatting",
-      "syncDescription": "Stop the VDB update flow in the sources panel so the backend can finish preparing the RAG before you chat."
+      "indexingInactiveTitle": "Start the first indexing run to enable chat",
+      "indexingInactiveDescriptionAdmin": "Open the sources panel and start the first VDB indexing run when your connected sources are selected for retrieval. Once it finishes, chat will be enabled and you can keep using it even while later indexing runs are active.",
+      "indexingInactiveDescriptionUser": "Open the sources panel and ask an administrator to start the first VDB indexing run when your connected sources are ready. Once it finishes, chat will be enabled and you can keep using it even while later indexing runs are active.",
+      "syncTitle": "The first indexing run is still in progress",
+      "syncDescription": "Chat will be enabled automatically when this first indexing run finishes. After that, you can keep using chat even while later indexing runs are active."
     },
     "composer": {
       "placeholder": "Ask a question about your documents, processes, or data...",
       "disabledHint": "Chat stays disabled until at least one connected source is selected for retrieval.",
-      "disabledHintIndexingInactiveAdmin": "Chat stays disabled until VDB indexing is started. Open the sources panel and start indexing when your sources are selected.",
-      "disabledHintIndexingInactiveUser": "Chat stays disabled until VDB indexing is started. Open the sources panel and ask an administrator to start indexing when your sources are ready.",
-      "finishSetupHint": "Finish the source setup flow in the sources panel before chatting."
+      "disabledHintIndexingInactiveAdmin": "Chat will be enabled after the first VDB indexing run. Open the sources panel and start that first run when your sources are selected.",
+      "disabledHintIndexingInactiveUser": "Chat will be enabled after the first VDB indexing run. Open the sources panel and ask an administrator to start that first run when your sources are ready.",
+      "finishSetupHint": "Chat will be enabled automatically when the first VDB indexing run finishes."
     },
     "messages": {
       "assistant": "Assistant",

--- a/frontend/src/i18n/messages/es.json
+++ b/frontend/src/i18n/messages/es.json
@@ -294,18 +294,18 @@
       "description": "Elige una conversación existente o inicia una nueva para hablar con el asistente.",
       "gatedTitle": "Conecta y selecciona al menos una fuente",
       "gatedDescription": "Abre el panel de fuentes para iniciar el flujo de preparación antes de empezar la conversación.",
-      "indexingInactiveTitle": "El indexado aún no está activo",
-      "indexingInactiveDescriptionAdmin": "Abre el panel de fuentes e inicia el indexado VDB cuando las fuentes conectadas estén seleccionadas para la recuperación.",
-      "indexingInactiveDescriptionUser": "Abre el panel de fuentes y pide a un administrador que inicie el indexado VDB cuando las fuentes conectadas estén listas.",
-      "syncTitle": "Termina la preparación de fuentes antes de chatear",
-      "syncDescription": "Detén el flujo de actualización de VDB en el panel de fuentes para que el backend termine de preparar el RAG antes de chatear."
+      "indexingInactiveTitle": "Inicia el primer indexado para habilitar el chat",
+      "indexingInactiveDescriptionAdmin": "Abre el panel de fuentes e inicia el primer indexado VDB cuando las fuentes conectadas estén seleccionadas para la recuperación. Cuando termine, el chat quedará habilitado y podrás seguir usándolo aunque haya nuevos indexados en marcha.",
+      "indexingInactiveDescriptionUser": "Abre el panel de fuentes y pide a un administrador que inicie el primer indexado VDB cuando las fuentes conectadas estén listas. Cuando termine, el chat quedará habilitado y podrás seguir usándolo aunque haya nuevos indexados en marcha.",
+      "syncTitle": "El primer indexado todavía está en curso",
+      "syncDescription": "El chat se habilitará automáticamente cuando termine este primer indexado. Después podrás seguir usando el chat aunque haya nuevos indexados en marcha."
     },
     "composer": {
       "placeholder": "Haz una pregunta sobre tus documentos, procesos o datos...",
       "disabledHint": "El chat permanece deshabilitado hasta que al menos una fuente conectada esté seleccionada para recuperación.",
-      "disabledHintIndexingInactiveAdmin": "El chat permanece deshabilitado hasta que se inicie el indexado VDB. Abre el panel de fuentes e inicia el indexado cuando tengas fuentes seleccionadas.",
-      "disabledHintIndexingInactiveUser": "El chat permanece deshabilitado hasta que el indexado VDB esté en marcha. Abre el panel de fuentes y pide a un administrador que inicie el indexado cuando las fuentes estén listas.",
-      "finishSetupHint": "Termina el flujo de preparación de fuentes en el panel antes de chatear."
+      "disabledHintIndexingInactiveAdmin": "El chat se habilitará después del primer indexado VDB. Abre el panel de fuentes e inicia ese primer indexado cuando tengas fuentes seleccionadas.",
+      "disabledHintIndexingInactiveUser": "El chat se habilitará después del primer indexado VDB. Abre el panel de fuentes y pide a un administrador que inicie ese primer indexado cuando las fuentes estén listas.",
+      "finishSetupHint": "El chat se habilitará automáticamente cuando termine el primer indexado VDB."
     },
     "messages": {
       "assistant": "Asistente",

--- a/frontend/src/i18n/messages/gl.json
+++ b/frontend/src/i18n/messages/gl.json
@@ -294,18 +294,18 @@
       "description": "Escolle unha conversa existente ou inicia unha nova para falar co asistente.",
       "gatedTitle": "Conecta e selecciona polo menos unha fonte",
       "gatedDescription": "Abre o panel de fontes para iniciar o fluxo de preparación antes de empezar a conversa.",
-      "indexingInactiveTitle": "O indexado aínda non está activo",
-      "indexingInactiveDescriptionAdmin": "Abre o panel de fontes e inicia o indexado VDB cando as fontes conectadas estean seleccionadas para a recuperación.",
-      "indexingInactiveDescriptionUser": "Abre o panel de fontes e pídelle a un administrador que inicie o indexado VDB cando as fontes conectadas estean listas.",
-      "syncTitle": "Remata a preparación de fontes antes de chatear",
-      "syncDescription": "Detén o fluxo de actualización de VDB no panel de fontes para que o backend remate de preparar o RAG antes de chatear."
+      "indexingInactiveTitle": "Inicia o primeiro indexado para habilitar o chat",
+      "indexingInactiveDescriptionAdmin": "Abre o panel de fontes e inicia o primeiro indexado VDB cando as fontes conectadas estean seleccionadas para a recuperación. Cando remate, o chat quedará habilitado e poderás seguir usándoo aínda que haxa novos indexados en marcha.",
+      "indexingInactiveDescriptionUser": "Abre o panel de fontes e pídelle a un administrador que inicie o primeiro indexado VDB cando as fontes conectadas estean listas. Cando remate, o chat quedará habilitado e poderás seguir usándoo aínda que haxa novos indexados en marcha.",
+      "syncTitle": "O primeiro indexado aínda está en curso",
+      "syncDescription": "O chat habilitarase automaticamente cando remate este primeiro indexado. Despois poderás seguir usando o chat aínda que haxa novos indexados en marcha."
     },
     "composer": {
       "placeholder": "Fai unha pregunta sobre os teus documentos, procesos ou datos...",
       "disabledHint": "O chat permanece deshabilitado ata que polo menos unha fonte conectada estea seleccionada para a recuperación.",
-      "disabledHintIndexingInactiveAdmin": "O chat permanece deshabilitado ata que se inicie o indexado VDB. Abre o panel de fontes e inicia o indexado cando teñas fontes seleccionadas.",
-      "disabledHintIndexingInactiveUser": "O chat permanece deshabilitado ata que o indexado VDB estea en marcha. Abre o panel de fontes e pídelle a un administrador que inicie o indexado cando as fontes estean listas.",
-      "finishSetupHint": "Remata o fluxo de preparación de fontes no panel antes de chatear."
+      "disabledHintIndexingInactiveAdmin": "O chat habilitarase despois do primeiro indexado VDB. Abre o panel de fontes e inicia ese primeiro indexado cando teñas fontes seleccionadas.",
+      "disabledHintIndexingInactiveUser": "O chat habilitarase despois do primeiro indexado VDB. Abre o panel de fontes e pídelle a un administrador que inicie ese primeiro indexado cando as fontes estean listas.",
+      "finishSetupHint": "O chat habilitarase automaticamente cando remate o primeiro indexado VDB."
     },
     "messages": {
       "assistant": "Asistente",


### PR DESCRIPTION
Se ha añadido la funcionalidad de poder detectar la primera vez que se construye qdrant para poder evitar que los usuarios puedan hablar con el chat hasta que no se han terminado de cargar los datos la primera vez. También se han mejorado los textos de por qué no se puede hablar con el chat.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced chat onboarding guidance with clearer “setup in progress” and “awaiting first indexing” states, including updated composer hints and empty-state messaging that reflects the first indexing run.
* **Bug Fixes**
  * Chat availability now tracks the vector database initialization/indexing lifecycle more accurately, enabling the composer at the right time and showing correct “not available yet” feedback.
* **Tests**
  * Expanded chat page tests to validate composer gating, empty-state content, and optimistic message behavior across indexing and chat switching.
* **Chores**
  * Updated spell-check configuration (including added dictionary entries).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->