### PR TITLE
feat: list_documents tool for metadata-based document listing

### DIFF
--- a/backend/graph/model.py
+++ b/backend/graph/model.py
@@ -1,12 +1,12 @@
 from pathlib import Path
 
 from dotenv.main import load_dotenv
-from .tools import vectordb_search
+from .tools import vectordb_search, list_documents
 
 
 load_dotenv(Path(__file__).resolve().parents[2] / ".env")
 
-tool_list = [vectordb_search]
+tool_list = [vectordb_search, list_documents]
 
 
 def get_llm_with_tools(llm):

--- a/backend/graph/tools.py
+++ b/backend/graph/tools.py
@@ -8,7 +8,7 @@ from langchain_core.tools import tool
 
 from src.config.env import get_env, get_bool_env
 from src.connectors.store import QDRANT_META_PATH
-from src.connectors.search import augment_chunks
+from src.connectors.search import augment_chunks, list_documents_by_metadata
 from src.metrics.metrics import (
     Metrics,
     TimedMetric,
@@ -16,8 +16,8 @@ from src.metrics.metrics import (
     register_topics,
     register_words,
 )
-from src.utils.nlp import extract_search_terms
-from src.utils.rag import retrieve_and_rerank, is_relevant_source, get_chunk_sources
+from src.utils.nlp import extract_search_terms, detect_language
+from src.utils.rag import retrieve_and_rerank, is_relevant_source, get_chunk_sources, _resolve_source_label
 from src.utils.topic import resolve_topic_names
 
 
@@ -140,4 +140,84 @@ def vectordb_search(query: str, config: RunnableConfig) -> str:
     return {
         "chunks": formatted_chunks,
         "sources": available_sources
+    }
+
+
+@tool
+def list_documents(
+    query: str,
+    config: RunnableConfig,
+    date_from: str | None = None,
+    date_to: str | None = None,
+    max_results: int = 20,
+) -> dict | str:
+    """Lists documents matching metadata criteria (file name, folder path,
+    modification date). Use this tool when the user asks for a LIST of
+    documents (e.g. "which documents...", "list the meeting minutes from
+    2025") instead of asking a question about their content.
+
+    Args:
+        query: keywords to match against the document name and folder path
+            (e.g. "actas reuniones"). Use an empty string to match all.
+        date_from: optional start date filter on the modification date;
+            accepts a year ("2025"), a month ("2025-03") or an ISO date.
+        date_to: optional end date filter, same formats as date_from.
+        max_results: maximum number of documents to return (default 20).
+    """
+
+    configurable = config.get("configurable", {})
+    vectorstore = configurable["vectorstore"]
+    sources = configurable["sources"]
+
+    try:
+        documents = list_documents_by_metadata(
+            vectorstore,
+            sources,
+            query=query,
+            date_from=date_from,
+            date_to=date_to,
+            max_results=max_results,
+        )
+
+    except Exception:
+        logging.exception("list_documents failed")
+        return "[Search error: the document listing is temporarily unavailable.]"
+
+    if not documents:
+        try:
+            lang_code = detect_language(query) if query.strip() else "es"
+        except Exception:
+            lang_code = "es"
+
+        fallback_messages = {
+            "es": "No encontré documentos que cumplan esos criterios en las fuentes disponibles.",
+            "en": "I couldn't find documents matching those criteria in the available sources.",
+            "gl": "Non atopei documentos que cumpran eses criterios nas fontes dispoñibles.",
+        }
+        return fallback_messages.get(lang_code, fallback_messages["es"])
+
+    formatted_docs = []
+
+    for doc in documents:
+        formatted_docs.append(
+            '['
+            f'file: {doc["path"]}; '
+            f'authors: {", ".join(doc["authors"])}; '
+            f'date: {doc["modifiedTime"]}'
+            ']'
+        )
+
+    available_sources = [
+        {
+            "id": doc["id"],
+            "title": doc["title"],
+            "source_type": _resolve_source_label(doc["source"], sources),
+            "link": doc["link"],
+        }
+        for doc in documents
+    ]
+
+    return {
+        "documents": formatted_docs,
+        "sources": available_sources,
     }

--- a/backend/server.py
+++ b/backend/server.py
@@ -577,7 +577,7 @@ def get_vectordb_search_output_in_latest_turn(messages: list[Any]) -> Any | None
             continue
 
         for tool_call in message.tool_calls or []:
-            if tool_call.get("name") != "vectordb_search":
+            if tool_call.get("name") not in ("vectordb_search", "list_documents"):
                 continue
 
             call_id = tool_call.get("id")

--- a/backend/src/connectors/search.py
+++ b/backend/src/connectors/search.py
@@ -1,9 +1,13 @@
+import unicodedata
+from datetime import datetime, timezone
+
 from langchain_community.vectorstores import Qdrant
 from langchain_core.documents import Document
 
 from qdrant_client.http.models import Filter
 from qdrant_client.http.models import Fusion, FusionQuery, Prefetch, FieldCondition, MatchValue, Range, Document as QDocument
 
+from src.config.env import get_bool_env
 from src.config.search_config import APPROX_SEARCH_PARAMS, PREV_CHUNKS, NEXT_CHUNKS
 from src.connectors.source import DataSource
 from src.connectors.store import BM25_MODEL, iterate_qdrant_docs
@@ -145,3 +149,134 @@ def hybrid_search(
     res = [d for _, d in search_results]
 
     return res
+
+
+# ---------------------------------
+# Document listing by metadata
+# ---------------------------------
+
+MAX_LIST_RESULTS = 50
+
+
+def _normalize_text(text: str) -> str:
+    """Lowercase and strip accents so queries match titles/paths loosely."""
+    nfkd = unicodedata.normalize("NFKD", text or "")
+    return "".join(c for c in nfkd if not unicodedata.combining(c)).lower()
+
+
+def _parse_date_bound(value: str, is_end: bool) -> datetime:
+    """Parse a lenient date bound: '2025', '2025-03' or full ISO date/datetime.
+
+    Start bounds default to the earliest instant of the period, end bounds to
+    the latest, so '2025' as date_to covers the whole year.
+    """
+    value = value.strip()
+    parts = value.split("-")
+
+    if len(parts) == 1 and parts[0].isdigit() and len(parts[0]) == 4:
+        if is_end:
+            return datetime(int(parts[0]), 12, 31, 23, 59, 59, tzinfo=timezone.utc)
+        return datetime(int(parts[0]), 1, 1, tzinfo=timezone.utc)
+
+    if len(parts) == 2 and all(p.isdigit() for p in parts):
+        year, month = int(parts[0]), int(parts[1])
+        if is_end:
+            if month == 12:
+                return datetime(year, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
+            return datetime(year, month + 1, 1, tzinfo=timezone.utc)
+        return datetime(year, month, 1, tzinfo=timezone.utc)
+
+    dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _parse_modified_time(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def list_documents_by_metadata(
+    vectorstore: Qdrant,
+    sources: dict[str, DataSource] | None = None,
+    query: str = "",
+    date_from: str | None = None,
+    date_to: str | None = None,
+    max_results: int = 20,
+) -> list[dict]:
+    """List distinct indexed documents matching metadata criteria.
+
+    Applies the same two-layer permission model as retrieval: a Qdrant
+    payload filter on the indexed ACLs, then a live `has_access` check per
+    candidate document against the source (skipped in benchmark mode).
+    """
+    max_results = max(1, min(int(max_results), MAX_LIST_RESULTS))
+
+    query_terms = [t for t in _normalize_text(query).split() if t]
+    start = _parse_date_bound(date_from, is_end=False) if date_from else None
+    end = _parse_date_bound(date_to, is_end=True) if date_to else None
+
+    # Scroll the whole (permission-filtered) collection and keep one
+    # representative metadata record per document id.
+    pfilter = get_permission_filter(sources)
+    documents: dict[str, dict] = {}
+
+    for _, doc in iterate_qdrant_docs(vectorstore, scroll_filter=pfilter):
+        meta = doc.metadata
+        doc_id = meta.get("id")
+
+        if not doc_id or doc_id in documents:
+            continue
+
+        haystack = _normalize_text(f'{meta.get("name", "")} {meta.get("path", "")}')
+
+        if query_terms and not all(t in haystack for t in query_terms):
+            continue
+
+        modified = _parse_modified_time(meta.get("modifiedTime"))
+
+        if start and (modified is None or modified < start):
+            continue
+
+        if end and (modified is None or modified > end):
+            continue
+
+        documents[doc_id] = {
+            "id": doc_id,
+            "title": meta.get("title") or meta.get("name") or "(sin titulo)",
+            "path": meta.get("path", ""),
+            "authors": meta.get("authors", []),
+            "mimeType": meta.get("mimeType"),
+            "modifiedTime": meta.get("modifiedTime"),
+            "link": meta.get("webViewLink"),
+            "source": meta.get("source"),
+            "_modified": modified or datetime.min.replace(tzinfo=timezone.utc),
+        }
+
+    # Most recently modified first
+    candidates = sorted(documents.values(), key=lambda d: d["_modified"], reverse=True)
+
+    # Live permission check per candidate, same as retrieve_and_rerank
+    allowed = []
+    check_live = not get_bool_env("BENCHMARK")
+
+    for doc in candidates:
+        if check_live:
+            source = sources.get(doc["source"]) if sources else None
+
+            if source is None or not source.has_access(doc["id"]):
+                continue
+
+        doc.pop("_modified")
+        allowed.append(doc)
+
+        if len(allowed) >= max_results:
+            break
+
+    return allowed

--- a/backend/src/utils/rag.py
+++ b/backend/src/utils/rag.py
@@ -151,6 +151,9 @@ def get_rag_system_prompt(lang_code: str) -> str:
     """Build the RAG system prompt with the detected language."""
     return (
         "You are a RAG conversational assistant. Use the available search tools when the user needs information from connected documents. "
+        "Use the vectordb_search tool when the user asks a question about the CONTENT of documents. "
+        "Use the list_documents tool when the user asks for a LIST of documents matching some criteria "
+        "(e.g. document type, topic in the file name or folder, or a date range), and present the results as a list. "
         "Respond EXCLUSIVELY in the language of the last message of the user, "
         f"which has been detected to have the following language code: {lang_code}. "
         "When you use retrieved context, answer only with information supported by it and do not improvise. "

--- a/backend/tests/test_list_documents.py
+++ b/backend/tests/test_list_documents.py
@@ -1,0 +1,156 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from langchain_core.documents import Document
+from qdrant_client.http.models import Filter
+
+from src.connectors.search import (
+    MAX_LIST_RESULTS,
+    _normalize_text,
+    _parse_date_bound,
+    list_documents_by_metadata,
+)
+
+
+def make_chunk(doc_id, name, path, modified_time, source="drive", chunk_idx=0):
+    return Document(
+        page_content="chunk content",
+        metadata={
+            "id": doc_id,
+            "name": name,
+            "path": path,
+            "authors": ["Autor de Prueba"],
+            "mimeType": "application/pdf",
+            "modifiedTime": modified_time,
+            "webViewLink": f"https://drive.example/{doc_id}",
+            "source": source,
+            "chunk_idx": chunk_idx,
+        },
+    )
+
+
+DOCS = [
+    make_chunk("doc-1", "Acta reunión enero.pdf", "Actas/2025/Acta reunión enero.pdf", "2025-01-15T10:00:00.000Z"),
+    make_chunk("doc-1", "Acta reunión enero.pdf", "Actas/2025/Acta reunión enero.pdf", "2025-01-15T10:00:00.000Z", chunk_idx=1),
+    make_chunk("doc-2", "Acta reunión marzo.pdf", "Actas/2025/Acta reunión marzo.pdf", "2025-03-10T10:00:00.000Z"),
+    make_chunk("doc-3", "Acta antigua.pdf", "Actas/2024/Acta antigua.pdf", "2024-06-20T10:00:00.000Z"),
+    make_chunk("doc-4", "Presupuesto 2025.xlsx", "Finanzas/Presupuesto 2025.xlsx", "2025-02-01T10:00:00.000Z"),
+]
+
+
+class FakeSource:
+    display_name = "Google Drive de prueba"
+
+    def __init__(self, allowed_ids):
+        self.allowed_ids = set(allowed_ids)
+
+    def get_permissions_filter(self):
+        return Filter()
+
+    def has_access(self, file_id):
+        return file_id in self.allowed_ids
+
+
+def run_listing(docs, sources, **kwargs):
+    with patch(
+        "src.connectors.search.iterate_qdrant_docs",
+        return_value=iter([(f"point-{i}", d) for i, d in enumerate(docs)]),
+    ):
+        return list_documents_by_metadata(object(), sources, **kwargs)
+
+
+class ListDocumentsTests(unittest.TestCase):
+    def setUp(self):
+        # Ensure the live permission check path is exercised by default
+        os.environ.pop("BENCHMARK", None)
+        self.sources = {"drive": FakeSource({"doc-1", "doc-2", "doc-3", "doc-4"})}
+
+    def test_normalize_text_strips_accents_and_case(self):
+        self.assertEqual(_normalize_text("Acta Reunión"), "acta reunion")
+
+    def test_query_matches_name_and_path_ignoring_accents(self):
+        result = run_listing(DOCS, self.sources, query="acta reunion")
+
+        self.assertEqual([d["id"] for d in result], ["doc-2", "doc-1"])
+
+    def test_query_requires_all_terms(self):
+        result = run_listing(DOCS, self.sources, query="acta marzo")
+
+        self.assertEqual([d["id"] for d in result], ["doc-2"])
+
+    def test_empty_query_returns_all_permitted_documents(self):
+        result = run_listing(DOCS, self.sources, query="")
+
+        self.assertEqual(len(result), 4)
+
+    def test_chunks_of_same_document_are_deduplicated(self):
+        result = run_listing(DOCS, self.sources, query="")
+
+        ids = [d["id"] for d in result]
+        self.assertEqual(len(ids), len(set(ids)))
+
+    def test_year_range_filters_by_modified_time(self):
+        result = run_listing(
+            DOCS, self.sources, query="acta", date_from="2025", date_to="2025"
+        )
+
+        self.assertEqual([d["id"] for d in result], ["doc-2", "doc-1"])
+
+    def test_month_range(self):
+        result = run_listing(
+            DOCS, self.sources, query="", date_from="2025-01", date_to="2025-01"
+        )
+
+        self.assertEqual([d["id"] for d in result], ["doc-1"])
+
+    def test_results_sorted_by_modified_time_desc(self):
+        result = run_listing(DOCS, self.sources, query="acta")
+
+        self.assertEqual([d["id"] for d in result], ["doc-2", "doc-1", "doc-3"])
+
+    def test_live_permission_check_excludes_inaccessible_documents(self):
+        sources = {"drive": FakeSource({"doc-1"})}
+        result = run_listing(DOCS, sources, query="acta")
+
+        self.assertEqual([d["id"] for d in result], ["doc-1"])
+
+    def test_document_from_unselected_source_is_excluded(self):
+        docs = DOCS + [
+            make_chunk("doc-5", "Acta dropbox.pdf", "Actas/Acta dropbox.pdf", "2025-04-01T10:00:00.000Z", source="dropbox")
+        ]
+        result = run_listing(docs, self.sources, query="acta")
+
+        self.assertNotIn("doc-5", [d["id"] for d in result])
+
+    def test_max_results_is_enforced(self):
+        result = run_listing(DOCS, self.sources, query="", max_results=2)
+
+        self.assertEqual(len(result), 2)
+
+    def test_max_results_capped_at_limit(self):
+        docs = [
+            make_chunk(f"doc-{i}", f"Acta {i}.pdf", f"Actas/Acta {i}.pdf", "2025-01-15T10:00:00.000Z")
+            for i in range(MAX_LIST_RESULTS + 10)
+        ]
+        sources = {"drive": FakeSource({f"doc-{i}" for i in range(MAX_LIST_RESULTS + 10)})}
+        result = run_listing(docs, sources, query="", max_results=1000)
+
+        self.assertEqual(len(result), MAX_LIST_RESULTS)
+
+    def test_benchmark_mode_skips_live_permission_check(self):
+        with patch.dict(os.environ, {"BENCHMARK": "true"}):
+            result = run_listing(DOCS, {}, query="acta")
+
+        self.assertEqual(len(result), 3)
+
+    def test_parse_date_bound_year(self):
+        start = _parse_date_bound("2025", is_end=False)
+        end = _parse_date_bound("2025", is_end=True)
+
+        self.assertEqual((start.year, start.month, start.day), (2025, 1, 1))
+        self.assertEqual((end.year, end.month, end.day), (2025, 12, 31))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/lib/logto.ts
+++ b/frontend/src/lib/logto.ts
@@ -14,5 +14,7 @@ export const logtoConfig: LogtoConfig = {
   endpoint,
   appId,
   resources: apiResource ? [apiResource] : [],
-  scopes: ['openid', 'profile', 'email', 'custom_data', 'identities', 'roles'],
+  // The API scope must be requested explicitly or the resource access token
+  // comes back with an empty scope and no roles claim (RBAC breaks).
+  scopes: ['openid', 'profile', 'email', 'custom_data', 'identities', 'roles', 'use:api'],
 }


### PR DESCRIPTION
## Qué hace

Nueva tool del agente LangGraph, `list_documents`, que lista documentos por criterios de **metadatos** (nombre/ruta y fecha de modificación) en lugar de buscar en el contenido. Pensada para peticiones tipo _«dame las actas de reuniones de 2025»_.

- `src/connectors/search.py` — `list_documents_by_metadata()`: scroll de Qdrant solo con payloads, dedup por documento, filtro de términos sobre nombre+ruta (insensible a tildes/mayúsculas), rango de fechas flexible (`2025`, `2025-03`, ISO), orden por fecha desc, cap de 50.
- **Permisos**: reutiliza el modelo de dos capas del retrieval — filtro de ACLs en payload de Qdrant + verificación en vivo `has_access` por documento (saltada solo en modo `BENCHMARK`). Documentos de fuentes no seleccionadas o sin acceso nunca se listan.
- `graph/tools.py` + `graph/model.py` — tool registrada; devuelve `{documents, sources}` con el mismo formato de citas que `vectordb_search`.
- `src/utils/rag.py` — el system prompt distingue cuándo usar cada tool (listado vs contenido).
- `server.py` — `get_vectordb_search_output_in_latest_turn` también extrae fuentes de `list_documents` para las citas del frontend.
- 14 tests nuevos en `backend/tests/test_list_documents.py` (22 en total pasan: `uv run python -m unittest discover tests`).

## Fix incluido: scopes de Logto (`frontend/src/lib/logto.ts`)

El SPA solo pedía scopes OIDC, así que el access token del API resource volvía con scope vacío y los endpoints con RBAC (start/stop VDB, alertas, métricas) devolvían 403. Se añade `use:api` a los scopes pedidos.

⚠️ **Acción necesaria al desplegar**: el permiso `use:api` debe existir en el API resource del tenant Logto correspondiente y estar asignado a los roles (admin/manager); si no, el login puede fallar por scope desconocido.

## Verificación end-to-end

Probado en un despliegue local completo (Logto + Drive indexado con ~40 docs):

- «Hazme un listado de los documentos Memoria KC» → usa `list_documents`, devuelve 11 docs con citas a Drive.
- «¿Qué documentos hay de 2025?» → filtro de fecha correcto, 20 fuentes de 2025.
- Pregunta de contenido → sigue usando `vectordb_search` como antes.

Limitación conocida: el matching es por palabras sobre nombre/ruta (los metadatos disponibles); no hay clasificación semántica del tipo de documento.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added document listing through natural-language searches using document names, paths, topics, types, and modification-date ranges.
  - Results include document labels and source links, with relevance filtering, duplicate removal, sorting, and result limits.
  - Search responses now support both content searches and document-list requests.

- **Improvements**
  - Enhanced matching for accented text and date-based filtering.
  - Improved handling of permissions, unavailable sources, empty results, and backend errors.
  - Enabled explicit API access scope requests during sign-in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->