### PR TITLE
feat: list_documents tool for metadata-based document listing

### DIFF
--- a/backend/graph/model.py
+++ b/backend/graph/model.py
@@ -1,12 +1,12 @@
 from pathlib import Path
 
 from dotenv.main import load_dotenv
-from .tools import vectordb_search
+from .tools import vectordb_search, list_documents
 
 
 load_dotenv(Path(__file__).resolve().parents[2] / ".env")
 
-tool_list = [vectordb_search]
+tool_list = [vectordb_search, list_documents]
 
 
 def get_llm_with_tools(llm):

--- a/backend/graph/tools.py
+++ b/backend/graph/tools.py
@@ -1,7 +1,10 @@
 from concurrent.futures import ThreadPoolExecutor
+from datetime import date
 import logging
 import os
+from typing import Annotated
 
+from pydantic import Field
 from treedex import TreeDex, OpenAILLM
 from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
@@ -22,7 +25,25 @@ from src.utils.topic import resolve_topic_names
 
 
 @tool
-def vectordb_search(query: str, config: RunnableConfig) -> str:
+def vectordb_search(
+    query: Annotated[
+        str,
+        Field(
+            description="Fully self-contained search query for the user's "
+            "information need."
+        ),
+    ],
+    config: RunnableConfig,
+    files: Annotated[
+        list[dict] | None,
+        Field(
+            description="Optional list of documents to restrict the search to, "
+            "as {'source': ..., 'id': ...} pairs taken from a previous "
+            "list_documents call. Use it to search content only within "
+            "documents the user has already identified."
+        ),
+    ] = None,
+) -> str:
     """Searches for documents relevant to the user's query through hybrid-search in a database."""
 
     configurable = config.get("configurable", {})
@@ -37,7 +58,7 @@ def vectordb_search(query: str, config: RunnableConfig) -> str:
     try:
         with TimedMetric(pool, Metrics.DOC_RESPONSE_TIME.value, actor=metrics_actor):
             chunks, lang_code = retrieve_and_rerank(
-                query, vectorstore, reranker, sources
+                query, vectorstore, reranker, sources, files=files
             )
 
     except Exception:
@@ -145,25 +166,40 @@ def vectordb_search(query: str, config: RunnableConfig) -> str:
 
 @tool
 def list_documents(
-    query: str,
+    query: Annotated[
+        str,
+        Field(
+            description="Keywords to match against the document name and folder "
+            "path (e.g. 'actas reuniones'). Use an empty string to match all."
+        ),
+    ],
     config: RunnableConfig,
-    date_from: str | None = None,
-    date_to: str | None = None,
-    max_results: int = 20,
+    date_from: Annotated[
+        date | None,
+        Field(
+            description="Optional start date (ISO YYYY-MM-DD) to filter by "
+            "modification date. If the user asks for a whole year or month, "
+            "use its first day (e.g. 2025-01-01)."
+        ),
+    ] = None,
+    date_to: Annotated[
+        date | None,
+        Field(
+            description="Optional end date (ISO YYYY-MM-DD) to filter by "
+            "modification date. If the user asks for a whole year or month, "
+            "use its last day (e.g. 2025-12-31)."
+        ),
+    ] = None,
+    max_results: Annotated[
+        int, Field(description="Maximum number of documents to return.")
+    ] = 20,
 ) -> dict | str:
     """Lists documents matching metadata criteria (file name, folder path,
     modification date). Use this tool when the user asks for a LIST of
     documents (e.g. "which documents...", "list the meeting minutes from
-    2025") instead of asking a question about their content.
-
-    Args:
-        query: keywords to match against the document name and folder path
-            (e.g. "actas reuniones"). Use an empty string to match all.
-        date_from: optional start date filter on the modification date;
-            accepts a year ("2025"), a month ("2025-03") or an ISO date.
-        date_to: optional end date filter, same formats as date_from.
-        max_results: maximum number of documents to return (default 20).
-    """
+    2025") instead of asking a question about their content. Each returned
+    document includes its id and source, which can be passed to
+    vectordb_search's files parameter to search content within them."""
 
     configurable = config.get("configurable", {})
     vectorstore = configurable["vectorstore"]
@@ -201,6 +237,8 @@ def list_documents(
     for doc in documents:
         formatted_docs.append(
             '['
+            f'id: {doc["id"]}; '
+            f'source: {doc["source"]}; '
             f'file: {doc["path"]}; '
             f'authors: {", ".join(doc["authors"])}; '
             f'date: {doc["modifiedTime"]}'

--- a/backend/graph/tools.py
+++ b/backend/graph/tools.py
@@ -8,7 +8,7 @@ from langchain_core.tools import tool
 
 from src.config.env import get_env, get_bool_env
 from src.connectors.store import QDRANT_META_PATH
-from src.connectors.search import augment_chunks
+from src.connectors.search import augment_chunks, list_documents_by_metadata
 from src.metrics.metrics import (
     Metrics,
     TimedMetric,
@@ -16,8 +16,8 @@ from src.metrics.metrics import (
     register_topics,
     register_words,
 )
-from src.utils.nlp import extract_search_terms
-from src.utils.rag import retrieve_and_rerank, is_relevant_source, get_chunk_sources
+from src.utils.nlp import extract_search_terms, detect_language
+from src.utils.rag import retrieve_and_rerank, is_relevant_source, get_chunk_sources, _resolve_source_label
 from src.utils.topic import resolve_topic_names
 
 
@@ -140,4 +140,84 @@ def vectordb_search(query: str, config: RunnableConfig) -> str:
     return {
         "chunks": formatted_chunks,
         "sources": available_sources
+    }
+
+
+@tool
+def list_documents(
+    query: str,
+    config: RunnableConfig,
+    date_from: str | None = None,
+    date_to: str | None = None,
+    max_results: int = 20,
+) -> dict | str:
+    """Lists documents matching metadata criteria (file name, folder path,
+    modification date). Use this tool when the user asks for a LIST of
+    documents (e.g. "which documents...", "list the meeting minutes from
+    2025") instead of asking a question about their content.
+
+    Args:
+        query: keywords to match against the document name and folder path
+            (e.g. "actas reuniones"). Use an empty string to match all.
+        date_from: optional start date filter on the modification date;
+            accepts a year ("2025"), a month ("2025-03") or an ISO date.
+        date_to: optional end date filter, same formats as date_from.
+        max_results: maximum number of documents to return (default 20).
+    """
+
+    configurable = config.get("configurable", {})
+    vectorstore = configurable["vectorstore"]
+    sources = configurable["sources"]
+
+    try:
+        documents = list_documents_by_metadata(
+            vectorstore,
+            sources,
+            query=query,
+            date_from=date_from,
+            date_to=date_to,
+            max_results=max_results,
+        )
+
+    except Exception:
+        logging.exception("list_documents failed")
+        return "[Search error: the document listing is temporarily unavailable.]"
+
+    if not documents:
+        try:
+            lang_code = detect_language(query) if query.strip() else "es"
+        except Exception:
+            lang_code = "es"
+
+        fallback_messages = {
+            "es": "No encontré documentos que cumplan esos criterios en las fuentes disponibles.",
+            "en": "I couldn't find documents matching those criteria in the available sources.",
+            "gl": "Non atopei documentos que cumpran eses criterios nas fontes dispoñibles.",
+        }
+        return fallback_messages.get(lang_code, fallback_messages["es"])
+
+    formatted_docs = []
+
+    for doc in documents:
+        formatted_docs.append(
+            '['
+            f'file: {doc["path"]}; '
+            f'authors: {", ".join(doc["authors"])}; '
+            f'date: {doc["modifiedTime"]}'
+            ']'
+        )
+
+    available_sources = [
+        {
+            "id": doc["id"],
+            "title": doc["title"],
+            "source_type": _resolve_source_label(doc["source"], sources),
+            "link": doc["link"],
+        }
+        for doc in documents
+    ]
+
+    return {
+        "documents": formatted_docs,
+        "sources": available_sources,
     }

--- a/backend/server.py
+++ b/backend/server.py
@@ -577,7 +577,7 @@ def get_vectordb_search_output_in_latest_turn(messages: list[Any]) -> Any | None
             continue
 
         for tool_call in message.tool_calls or []:
-            if tool_call.get("name") != "vectordb_search":
+            if tool_call.get("name") not in ("vectordb_search", "list_documents"):
                 continue
 
             call_id = tool_call.get("id")

--- a/backend/src/connectors/search.py
+++ b/backend/src/connectors/search.py
@@ -1,9 +1,13 @@
+import unicodedata
+from datetime import datetime, timezone
+
 from langchain_community.vectorstores import Qdrant
 from langchain_core.documents import Document
 
 from qdrant_client.http.models import Filter
 from qdrant_client.http.models import Fusion, FusionQuery, Prefetch, FieldCondition, MatchValue, Range, Document as QDocument
 
+from src.config.env import get_bool_env
 from src.config.search_config import APPROX_SEARCH_PARAMS, PREV_CHUNKS, NEXT_CHUNKS
 from src.connectors.source import DataSource
 from src.connectors.store import BM25_MODEL, iterate_qdrant_docs
@@ -145,3 +149,134 @@ def hybrid_search(
     res = [d for _, d in search_results]
 
     return res
+
+
+# ---------------------------------
+# Document listing by metadata
+# ---------------------------------
+
+MAX_LIST_RESULTS = 50
+
+
+def _normalize_text(text: str) -> str:
+    """Lowercase and strip accents so queries match titles/paths loosely."""
+    nfkd = unicodedata.normalize("NFKD", text or "")
+    return "".join(c for c in nfkd if not unicodedata.combining(c)).lower()
+
+
+def _parse_date_bound(value: str, is_end: bool) -> datetime:
+    """Parse a lenient date bound: '2025', '2025-03' or full ISO date/datetime.
+
+    Start bounds default to the earliest instant of the period, end bounds to
+    the latest, so '2025' as date_to covers the whole year.
+    """
+    value = value.strip()
+    parts = value.split("-")
+
+    if len(parts) == 1 and parts[0].isdigit() and len(parts[0]) == 4:
+        if is_end:
+            return datetime(int(parts[0]), 12, 31, 23, 59, 59, tzinfo=timezone.utc)
+        return datetime(int(parts[0]), 1, 1, tzinfo=timezone.utc)
+
+    if len(parts) == 2 and all(p.isdigit() for p in parts):
+        year, month = int(parts[0]), int(parts[1])
+        if is_end:
+            if month == 12:
+                return datetime(year, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
+            return datetime(year, month + 1, 1, tzinfo=timezone.utc)
+        return datetime(year, month, 1, tzinfo=timezone.utc)
+
+    dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _parse_modified_time(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def list_documents_by_metadata(
+    vectorstore: Qdrant,
+    sources: dict[str, DataSource] | None = None,
+    query: str = "",
+    date_from: str | None = None,
+    date_to: str | None = None,
+    max_results: int = 20,
+) -> list[dict]:
+    """List distinct indexed documents matching metadata criteria.
+
+    Applies the same two-layer permission model as retrieval: a Qdrant
+    payload filter on the indexed ACLs, then a live `has_access` check per
+    candidate document against the source (skipped in benchmark mode).
+    """
+    max_results = max(1, min(int(max_results), MAX_LIST_RESULTS))
+
+    query_terms = [t for t in _normalize_text(query).split() if t]
+    start = _parse_date_bound(date_from, is_end=False) if date_from else None
+    end = _parse_date_bound(date_to, is_end=True) if date_to else None
+
+    # Scroll the whole (permission-filtered) collection and keep one
+    # representative metadata record per document id.
+    pfilter = get_permission_filter(sources)
+    documents: dict[str, dict] = {}
+
+    for _, doc in iterate_qdrant_docs(vectorstore, scroll_filter=pfilter):
+        meta = doc.metadata
+        doc_id = meta.get("id")
+
+        if not doc_id or doc_id in documents:
+            continue
+
+        haystack = _normalize_text(f'{meta.get("name", "")} {meta.get("path", "")}')
+
+        if query_terms and not all(t in haystack for t in query_terms):
+            continue
+
+        modified = _parse_modified_time(meta.get("modifiedTime"))
+
+        if start and (modified is None or modified < start):
+            continue
+
+        if end and (modified is None or modified > end):
+            continue
+
+        documents[doc_id] = {
+            "id": doc_id,
+            "title": meta.get("title") or meta.get("name") or "(sin titulo)",
+            "path": meta.get("path", ""),
+            "authors": meta.get("authors", []),
+            "mimeType": meta.get("mimeType"),
+            "modifiedTime": meta.get("modifiedTime"),
+            "link": meta.get("webViewLink"),
+            "source": meta.get("source"),
+            "_modified": modified or datetime.min.replace(tzinfo=timezone.utc),
+        }
+
+    # Most recently modified first
+    candidates = sorted(documents.values(), key=lambda d: d["_modified"], reverse=True)
+
+    # Live permission check per candidate, same as retrieve_and_rerank
+    allowed = []
+    check_live = not get_bool_env("BENCHMARK")
+
+    for doc in candidates:
+        if check_live:
+            source = sources.get(doc["source"]) if sources else None
+
+            if source is None or not source.has_access(doc["id"]):
+                continue
+
+        doc.pop("_modified")
+        allowed.append(doc)
+
+        if len(allowed) >= max_results:
+            break
+
+    return allowed

--- a/backend/src/connectors/search.py
+++ b/backend/src/connectors/search.py
@@ -157,6 +157,9 @@ def hybrid_search(
 
 MAX_LIST_RESULTS = 50
 
+# Upper bound of document groups fetched in a single grouped query
+GROUP_QUERY_LIMIT = 10000
+
 
 def _normalize_text(text: str) -> str:
     """Lowercase and strip accents so queries match titles/paths loosely."""
@@ -222,16 +225,33 @@ def list_documents_by_metadata(
     start = _parse_date_bound(date_from, is_end=False) if date_from else None
     end = _parse_date_bound(date_to, is_end=True) if date_to else None
 
-    # Scroll the whole (permission-filtered) collection and keep one
-    # representative metadata record per document id.
+    # Fetch one representative chunk per document with a grouped query
+    # (group_by document id), instead of scanning every chunk and
+    # deduplicating client-side. query=None behaves as a traversal of the
+    # (permission-filtered) collection.
     pfilter = get_permission_filter(sources)
+    result = vectorstore.client.query_points_groups(
+        collection_name=vectorstore.collection_name,
+        group_by="metadata.id",
+        query=None,
+        query_filter=pfilter,
+        limit=GROUP_QUERY_LIMIT,
+        group_size=1,
+        with_payload=True,
+        with_vectors=False,
+        timeout=600,
+    )
+
     documents: dict[str, dict] = {}
 
-    for _, doc in iterate_qdrant_docs(vectorstore, scroll_filter=pfilter):
-        meta = doc.metadata
+    for group in result.groups:
+        if not group.hits:
+            continue
+
+        meta = (group.hits[0].payload or {}).get("metadata", {})
         doc_id = meta.get("id")
 
-        if not doc_id or doc_id in documents:
+        if not doc_id:
             continue
 
         haystack = _normalize_text(f'{meta.get("name", "")} {meta.get("path", "")}')

--- a/backend/src/connectors/search.py
+++ b/backend/src/connectors/search.py
@@ -1,5 +1,5 @@
 import unicodedata
-from datetime import datetime, timezone
+from datetime import date, datetime, time, timezone
 
 from langchain_community.vectorstores import Qdrant
 from langchain_core.documents import Document
@@ -19,6 +19,48 @@ def get_permission_filter(sources: dict[str, DataSource] | None = None):
 
     filters = [source.get_permissions_filter() for source in sources.values()]
     return Filter(should=filters) if filters else None
+
+
+def build_files_filter(files: list[dict] | None) -> Filter | None:
+    """Restrict a search to specific documents given as (source, id) pairs.
+
+    Used to chain list_documents into vectordb_search: the assistant lists
+    documents by metadata and then searches content only within them.
+    """
+    if not files:
+        return None
+
+    conditions = []
+
+    for f in files:
+        doc_id = f.get("id")
+        if not doc_id:
+            continue
+
+        must = [FieldCondition(key="metadata.id", match=MatchValue(value=doc_id))]
+
+        source = f.get("source")
+        if source:
+            must.append(
+                FieldCondition(key="metadata.source", match=MatchValue(value=source))
+            )
+
+        conditions.append(Filter(must=must))
+
+    return Filter(should=conditions) if conditions else None
+
+
+def combine_filters(*filters: Filter | None) -> Filter | None:
+    """AND several optional filters together."""
+    active = [f for f in filters if f is not None]
+
+    if not active:
+        return None
+
+    if len(active) == 1:
+        return active[0]
+
+    return Filter(must=active)
 
 
 def build_contiguous_chunk_filter(anchors: list[tuple[str, int]], num_previous: int, num_next: int) -> Filter:
@@ -117,12 +159,16 @@ def hybrid_search(
     k: int,
     prefetch_k: int,
     sources: dict[str, DataSource] | None = None,
+    files: list[dict] | None = None,
 ):
     # Embed query
     emb = vectorstore.embeddings.embed_query(query)
 
-    # Get permission filter
-    pfilter = get_permission_filter(sources)
+    # Get permission filter, optionally restricted to specific documents
+    pfilter = combine_filters(
+        get_permission_filter(sources),
+        build_files_filter(files),
+    )
 
     # Make search request to the server
     search_results = vectorstore.client.query_points(
@@ -167,32 +213,12 @@ def _normalize_text(text: str) -> str:
     return "".join(c for c in nfkd if not unicodedata.combining(c)).lower()
 
 
-def _parse_date_bound(value: str, is_end: bool) -> datetime:
-    """Parse a lenient date bound: '2025', '2025-03' or full ISO date/datetime.
+def _day_start(d: date) -> datetime:
+    return datetime.combine(d, time.min, tzinfo=timezone.utc)
 
-    Start bounds default to the earliest instant of the period, end bounds to
-    the latest, so '2025' as date_to covers the whole year.
-    """
-    value = value.strip()
-    parts = value.split("-")
 
-    if len(parts) == 1 and parts[0].isdigit() and len(parts[0]) == 4:
-        if is_end:
-            return datetime(int(parts[0]), 12, 31, 23, 59, 59, tzinfo=timezone.utc)
-        return datetime(int(parts[0]), 1, 1, tzinfo=timezone.utc)
-
-    if len(parts) == 2 and all(p.isdigit() for p in parts):
-        year, month = int(parts[0]), int(parts[1])
-        if is_end:
-            if month == 12:
-                return datetime(year, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
-            return datetime(year, month + 1, 1, tzinfo=timezone.utc)
-        return datetime(year, month, 1, tzinfo=timezone.utc)
-
-    dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    return dt
+def _day_end(d: date) -> datetime:
+    return datetime.combine(d, time.max, tzinfo=timezone.utc)
 
 
 def _parse_modified_time(value: str | None) -> datetime | None:
@@ -209,8 +235,8 @@ def list_documents_by_metadata(
     vectorstore: Qdrant,
     sources: dict[str, DataSource] | None = None,
     query: str = "",
-    date_from: str | None = None,
-    date_to: str | None = None,
+    date_from: date | None = None,
+    date_to: date | None = None,
     max_results: int = 20,
 ) -> list[dict]:
     """List distinct indexed documents matching metadata criteria.
@@ -222,8 +248,8 @@ def list_documents_by_metadata(
     max_results = max(1, min(int(max_results), MAX_LIST_RESULTS))
 
     query_terms = [t for t in _normalize_text(query).split() if t]
-    start = _parse_date_bound(date_from, is_end=False) if date_from else None
-    end = _parse_date_bound(date_to, is_end=True) if date_to else None
+    start = _day_start(date_from) if date_from else None
+    end = _day_end(date_to) if date_to else None
 
     # Fetch one representative chunk per document with a grouped query
     # (group_by document id), instead of scanning every chunk and

--- a/backend/src/utils/rag.py
+++ b/backend/src/utils/rag.py
@@ -151,6 +151,9 @@ def get_rag_system_prompt(lang_code: str) -> str:
     """Build the RAG system prompt with the detected language."""
     return (
         "You are a RAG conversational assistant. Use the available search tools when the user needs information from connected documents. "
+        "Use the vectordb_search tool when the user asks a question about the CONTENT of documents. "
+        "Use the list_documents tool when the user asks for a LIST of documents matching some criteria "
+        "(e.g. document type, topic in the file name or folder, or a date range), and present the results as a list. "
         "Respond EXCLUSIVELY in the language of the last message of the user, "
         f"which has been detected to have the following language code: {lang_code}. "
         "When you use retrieved context, answer only with information supported by it and do not improvise. "

--- a/backend/src/utils/rag.py
+++ b/backend/src/utils/rag.py
@@ -89,8 +89,12 @@ def rerank_documents(reranker, query: str, documents: list, top_k: int = None) -
     return reranked_docs
 
 
-def retrieve_and_rerank(query: str, vectordb, reranker, sources: Dict[str, DataSource], k: int = 6) -> tuple:
+def retrieve_and_rerank(query: str, vectordb, reranker, sources: Dict[str, DataSource], k: int = 6, files: list[dict] | None = None) -> tuple:
     """Retrieval-only function: hybrid search + permission filtering + reranking.
+
+    Args:
+        files: optional list of {'source', 'id'} pairs restricting the search
+            to specific documents (chaining from list_documents).
 
     Returns:
         (allowed_chunks, lang_code)
@@ -98,7 +102,7 @@ def retrieve_and_rerank(query: str, vectordb, reranker, sources: Dict[str, DataS
     lang_code = detect_language(query)
 
     # Perform hybrid search
-    search_results = hybrid_search(vectordb, query, 25, 25, sources)
+    search_results = hybrid_search(vectordb, query, 25, 25, sources, files=files)
 
     # Filter by permissions
     allowed_chunks = []
@@ -154,6 +158,9 @@ def get_rag_system_prompt(lang_code: str) -> str:
         "Use the vectordb_search tool when the user asks a question about the CONTENT of documents. "
         "Use the list_documents tool when the user asks for a LIST of documents matching some criteria "
         "(e.g. document type, topic in the file name or folder, or a date range), and present the results as a list. "
+        "You can chain both tools: after listing documents with list_documents, if the user wants to query "
+        "the CONTENT of those documents, call vectordb_search passing its files parameter the "
+        "{'source', 'id'} pairs from the list_documents output. "
         "Respond EXCLUSIVELY in the language of the last message of the user, "
         f"which has been detected to have the following language code: {lang_code}. "
         "When you use retrieved context, answer only with information supported by it and do not improvise. "

--- a/backend/tests/test_list_documents.py
+++ b/backend/tests/test_list_documents.py
@@ -52,12 +52,43 @@ class FakeSource:
         return file_id in self.allowed_ids
 
 
+class _FakeHit:
+    def __init__(self, metadata):
+        self.payload = {"metadata": metadata, "page_content": "chunk"}
+
+
+class _FakeGroup:
+    def __init__(self, doc_id, metadata):
+        self.id = doc_id
+        self.hits = [_FakeHit(metadata)]
+
+
+class _FakeGroupsResult:
+    def __init__(self, groups):
+        self.groups = groups
+
+
+class _FakeQdrantClient:
+    def __init__(self, docs):
+        self._docs = docs
+
+    def query_points_groups(self, **kwargs):
+        # Group chunks by document id, like Qdrant's group_by does
+        seen = {}
+        for doc in self._docs:
+            seen.setdefault(doc.metadata["id"], doc.metadata)
+        return _FakeGroupsResult([_FakeGroup(k, v) for k, v in seen.items()])
+
+
+class _FakeVectorstore:
+    collection_name = "documents"
+
+    def __init__(self, docs):
+        self.client = _FakeQdrantClient(docs)
+
+
 def run_listing(docs, sources, **kwargs):
-    with patch(
-        "src.connectors.search.iterate_qdrant_docs",
-        return_value=iter([(f"point-{i}", d) for i, d in enumerate(docs)]),
-    ):
-        return list_documents_by_metadata(object(), sources, **kwargs)
+    return list_documents_by_metadata(_FakeVectorstore(docs), sources, **kwargs)
 
 
 class ListDocumentsTests(unittest.TestCase):

--- a/backend/tests/test_list_documents.py
+++ b/backend/tests/test_list_documents.py
@@ -1,0 +1,156 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from langchain_core.documents import Document
+from qdrant_client.http.models import Filter
+
+from src.connectors.search import (
+    MAX_LIST_RESULTS,
+    _normalize_text,
+    _parse_date_bound,
+    list_documents_by_metadata,
+)
+
+
+def make_chunk(doc_id, name, path, modified_time, source="drive", chunk_idx=0):
+    return Document(
+        page_content="chunk content",
+        metadata={
+            "id": doc_id,
+            "name": name,
+            "path": path,
+            "authors": ["Autor de Prueba"],
+            "mimeType": "application/pdf",
+            "modifiedTime": modified_time,
+            "webViewLink": f"https://drive.example/{doc_id}",
+            "source": source,
+            "chunk_idx": chunk_idx,
+        },
+    )
+
+
+DOCS = [
+    make_chunk("doc-1", "Acta reunión enero.pdf", "Actas/2025/Acta reunión enero.pdf", "2025-01-15T10:00:00.000Z"),
+    make_chunk("doc-1", "Acta reunión enero.pdf", "Actas/2025/Acta reunión enero.pdf", "2025-01-15T10:00:00.000Z", chunk_idx=1),
+    make_chunk("doc-2", "Acta reunión marzo.pdf", "Actas/2025/Acta reunión marzo.pdf", "2025-03-10T10:00:00.000Z"),
+    make_chunk("doc-3", "Acta antigua.pdf", "Actas/2024/Acta antigua.pdf", "2024-06-20T10:00:00.000Z"),
+    make_chunk("doc-4", "Presupuesto 2025.xlsx", "Finanzas/Presupuesto 2025.xlsx", "2025-02-01T10:00:00.000Z"),
+]
+
+
+class FakeSource:
+    display_name = "Google Drive de prueba"
+
+    def __init__(self, allowed_ids):
+        self.allowed_ids = set(allowed_ids)
+
+    def get_permissions_filter(self):
+        return Filter()
+
+    def has_access(self, file_id):
+        return file_id in self.allowed_ids
+
+
+def run_listing(docs, sources, **kwargs):
+    with patch(
+        "src.connectors.search.iterate_qdrant_docs",
+        return_value=iter([(f"point-{i}", d) for i, d in enumerate(docs)]),
+    ):
+        return list_documents_by_metadata(object(), sources, **kwargs)
+
+
+class ListDocumentsTests(unittest.TestCase):
+    def setUp(self):
+        # Ensure the live permission check path is exercised by default
+        os.environ.pop("BENCHMARK", None)
+        self.sources = {"drive": FakeSource({"doc-1", "doc-2", "doc-3", "doc-4"})}
+
+    def test_normalize_text_strips_accents_and_case(self):
+        self.assertEqual(_normalize_text("Acta Reunión"), "acta reunion")
+
+    def test_query_matches_name_and_path_ignoring_accents(self):
+        result = run_listing(DOCS, self.sources, query="acta reunion")
+
+        self.assertEqual([d["id"] for d in result], ["doc-2", "doc-1"])
+
+    def test_query_requires_all_terms(self):
+        result = run_listing(DOCS, self.sources, query="acta marzo")
+
+        self.assertEqual([d["id"] for d in result], ["doc-2"])
+
+    def test_empty_query_returns_all_permitted_documents(self):
+        result = run_listing(DOCS, self.sources, query="")
+
+        self.assertEqual(len(result), 4)
+
+    def test_chunks_of_same_document_are_deduplicated(self):
+        result = run_listing(DOCS, self.sources, query="")
+
+        ids = [d["id"] for d in result]
+        self.assertEqual(len(ids), len(set(ids)))
+
+    def test_year_range_filters_by_modified_time(self):
+        result = run_listing(
+            DOCS, self.sources, query="acta", date_from="2025", date_to="2025"
+        )
+
+        self.assertEqual([d["id"] for d in result], ["doc-2", "doc-1"])
+
+    def test_month_range(self):
+        result = run_listing(
+            DOCS, self.sources, query="", date_from="2025-01", date_to="2025-01"
+        )
+
+        self.assertEqual([d["id"] for d in result], ["doc-1"])
+
+    def test_results_sorted_by_modified_time_desc(self):
+        result = run_listing(DOCS, self.sources, query="acta")
+
+        self.assertEqual([d["id"] for d in result], ["doc-2", "doc-1", "doc-3"])
+
+    def test_live_permission_check_excludes_inaccessible_documents(self):
+        sources = {"drive": FakeSource({"doc-1"})}
+        result = run_listing(DOCS, sources, query="acta")
+
+        self.assertEqual([d["id"] for d in result], ["doc-1"])
+
+    def test_document_from_unselected_source_is_excluded(self):
+        docs = DOCS + [
+            make_chunk("doc-5", "Acta dropbox.pdf", "Actas/Acta dropbox.pdf", "2025-04-01T10:00:00.000Z", source="dropbox")
+        ]
+        result = run_listing(docs, self.sources, query="acta")
+
+        self.assertNotIn("doc-5", [d["id"] for d in result])
+
+    def test_max_results_is_enforced(self):
+        result = run_listing(DOCS, self.sources, query="", max_results=2)
+
+        self.assertEqual(len(result), 2)
+
+    def test_max_results_capped_at_limit(self):
+        docs = [
+            make_chunk(f"doc-{i}", f"Acta {i}.pdf", f"Actas/Acta {i}.pdf", "2025-01-15T10:00:00.000Z")
+            for i in range(MAX_LIST_RESULTS + 10)
+        ]
+        sources = {"drive": FakeSource({f"doc-{i}" for i in range(MAX_LIST_RESULTS + 10)})}
+        result = run_listing(docs, sources, query="", max_results=1000)
+
+        self.assertEqual(len(result), MAX_LIST_RESULTS)
+
+    def test_benchmark_mode_skips_live_permission_check(self):
+        with patch.dict(os.environ, {"BENCHMARK": "true"}):
+            result = run_listing(DOCS, {}, query="acta")
+
+        self.assertEqual(len(result), 3)
+
+    def test_parse_date_bound_year(self):
+        start = _parse_date_bound("2025", is_end=False)
+        end = _parse_date_bound("2025", is_end=True)
+
+        self.assertEqual((start.year, start.month, start.day), (2025, 1, 1))
+        self.assertEqual((end.year, end.month, end.day), (2025, 12, 31))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_list_documents.py
+++ b/backend/tests/test_list_documents.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from datetime import date
 from unittest.mock import patch
 
 from langchain_core.documents import Document
@@ -7,8 +8,11 @@ from qdrant_client.http.models import Filter
 
 from src.connectors.search import (
     MAX_LIST_RESULTS,
+    _day_end,
+    _day_start,
     _normalize_text,
-    _parse_date_bound,
+    build_files_filter,
+    combine_filters,
     list_documents_by_metadata,
 )
 
@@ -123,14 +127,22 @@ class ListDocumentsTests(unittest.TestCase):
 
     def test_year_range_filters_by_modified_time(self):
         result = run_listing(
-            DOCS, self.sources, query="acta", date_from="2025", date_to="2025"
+            DOCS,
+            self.sources,
+            query="acta",
+            date_from=date(2025, 1, 1),
+            date_to=date(2025, 12, 31),
         )
 
         self.assertEqual([d["id"] for d in result], ["doc-2", "doc-1"])
 
     def test_month_range(self):
         result = run_listing(
-            DOCS, self.sources, query="", date_from="2025-01", date_to="2025-01"
+            DOCS,
+            self.sources,
+            query="",
+            date_from=date(2025, 1, 1),
+            date_to=date(2025, 1, 31),
         )
 
         self.assertEqual([d["id"] for d in result], ["doc-1"])
@@ -175,12 +187,35 @@ class ListDocumentsTests(unittest.TestCase):
 
         self.assertEqual(len(result), 3)
 
-    def test_parse_date_bound_year(self):
-        start = _parse_date_bound("2025", is_end=False)
-        end = _parse_date_bound("2025", is_end=True)
+    def test_day_bounds(self):
+        start = _day_start(date(2025, 3, 15))
+        end = _day_end(date(2025, 3, 15))
 
-        self.assertEqual((start.year, start.month, start.day), (2025, 1, 1))
-        self.assertEqual((end.year, end.month, end.day), (2025, 12, 31))
+        self.assertEqual((start.hour, start.minute, start.second), (0, 0, 0))
+        self.assertGreater(end, start)
+        self.assertEqual((end.year, end.month, end.day), (2025, 3, 15))
+
+    def test_build_files_filter_requires_source_and_id_pairs(self):
+        f = build_files_filter([
+            {"source": "drive", "id": "doc-1"},
+            {"source": "drive", "id": "doc-2"},
+        ])
+
+        self.assertIsNotNone(f)
+        self.assertEqual(len(f.should), 2)
+
+    def test_build_files_filter_skips_entries_without_id(self):
+        self.assertIsNone(build_files_filter([{"source": "drive"}]))
+        self.assertIsNone(build_files_filter(None))
+        self.assertIsNone(build_files_filter([]))
+
+    def test_combine_filters_and_semantics(self):
+        f1 = build_files_filter([{"id": "doc-1"}])
+        f2 = Filter()
+
+        self.assertIsNone(combine_filters(None, None))
+        self.assertIs(combine_filters(f1, None), f1)
+        self.assertEqual(len(combine_filters(f1, f2).must), 2)
 
 
 if __name__ == "__main__":

--- a/frontend/src/lib/logto.ts
+++ b/frontend/src/lib/logto.ts
@@ -14,5 +14,7 @@ export const logtoConfig: LogtoConfig = {
   endpoint,
   appId,
   resources: apiResource ? [apiResource] : [],
-  scopes: ['openid', 'profile', 'email', 'custom_data', 'identities', 'roles'],
+  // The API scope must be requested explicitly or the resource access token
+  // comes back with an empty scope and no roles claim (RBAC breaks).
+  scopes: ['openid', 'profile', 'email', 'custom_data', 'identities', 'roles', 'use:api'],
 }


### PR DESCRIPTION
## Qué hace

Nueva tool del agente LangGraph, `list_documents`, que lista documentos por criterios de **metadatos** (nombre/ruta y fecha de modificación) en lugar de buscar en el contenido. Pensada para peticiones tipo _«dame las actas de reuniones de 2025»_.

- `src/connectors/search.py` — `list_documents_by_metadata()`: scroll de Qdrant solo con payloads, dedup por documento, filtro de términos sobre nombre+ruta (insensible a tildes/mayúsculas), rango de fechas flexible (`2025`, `2025-03`, ISO), orden por fecha desc, cap de 50.
- **Permisos**: reutiliza el modelo de dos capas del retrieval — filtro de ACLs en payload de Qdrant + verificación en vivo `has_access` por documento (saltada solo en modo `BENCHMARK`). Documentos de fuentes no seleccionadas o sin acceso nunca se listan.
- `graph/tools.py` + `graph/model.py` — tool registrada; devuelve `{documents, sources}` con el mismo formato de citas que `vectordb_search`.
- `src/utils/rag.py` — el system prompt distingue cuándo usar cada tool (listado vs contenido).
- `server.py` — `get_vectordb_search_output_in_latest_turn` también extrae fuentes de `list_documents` para las citas del frontend.
- 14 tests nuevos en `backend/tests/test_list_documents.py` (22 en total pasan: `uv run python -m unittest discover tests`).

## Fix incluido: scopes de Logto (`frontend/src/lib/logto.ts`)

El SPA solo pedía scopes OIDC, así que el access token del API resource volvía con scope vacío y los endpoints con RBAC (start/stop VDB, alertas, métricas) devolvían 403. Se añade `use:api` a los scopes pedidos.

⚠️ **Acción necesaria al desplegar**: el permiso `use:api` debe existir en el API resource del tenant Logto correspondiente y estar asignado a los roles (admin/manager); si no, el login puede fallar por scope desconocido.

## Verificación end-to-end

Probado en un despliegue local completo (Logto + Drive indexado con ~40 docs):

- «Hazme un listado de los documentos Memoria KC» → usa `list_documents`, devuelve 11 docs con citas a Drive.
- «¿Qué documentos hay de 2025?» → filtro de fecha correcto, 20 fuentes de 2025.
- Pregunta de contenido → sigue usando `vectordb_search` como antes.

Limitación conocida: el matching es por palabras sobre nombre/ruta (los metadatos disponibles); no hay clasificación semántica del tipo de documento.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added document listing by topic, type, keywords, and modification date.
  * Results include document metadata, source details, sorting, filtering, and result limits.
  * The assistant now selects document listing or content search based on the request.
  * Content searches can be narrowed to documents selected from listing results.

* **Bug Fixes**
  * Document sources from listing requests are now included in chat results.

* **Tests**
  * Added coverage for filtering, permissions, dates, deduplication, sorting, and result limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->